### PR TITLE
feat: 도메인 엔티티 설계 및 구현

### DIFF
--- a/src/main/java/com/quadcore/voiceandtext/common/base/BaseEntity.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/base/BaseEntity.java
@@ -1,2 +1,15 @@
 package com.quadcore.voiceandtext.common.base;
-public class BaseEntity {}
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/com/quadcore/voiceandtext/common/base/BaseTimeEntity.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/base/BaseTimeEntity.java
@@ -1,5 +1,21 @@
 package com.quadcore.voiceandtext.common.base;
 
-public class BaseTimeEntity extends BaseEntity {
-    // TODO: createdAt, updatedAt fields
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseTimeEntity extends BaseEntity {
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisRequest.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisRequest.java
@@ -1,5 +1,58 @@
 package com.quadcore.voiceandtext.domain.analysis;
 
-public class AnalysisRequest {
-    // TODO: analysis request fields
+import com.quadcore.voiceandtext.common.base.BaseTimeEntity;
+import com.quadcore.voiceandtext.domain.file.AudioFile;
+import com.quadcore.voiceandtext.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "analysis_requests")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnalysisRequest extends BaseTimeEntity {
+    @Column(length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = true)
+    private User user;
+
+    @Column(nullable = false)
+    private Boolean isGuest;
+
+    @Column(length = 100)
+    private String guestEmail;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "audio_file_id", nullable = false)
+    private AudioFile audioFile;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "transcription_id", nullable = false)
+    private Transcription transcription;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "analysis_result_id")
+    private AnalysisResult analysisResult;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnalysisStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnalysisType analysisType;
+
+    @Column
+    private Integer priority;
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
 }

--- a/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisResult.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisResult.java
@@ -1,5 +1,44 @@
 package com.quadcore.voiceandtext.domain.analysis;
 
-public class AnalysisResult {
-    // TODO: analysis result fields
+import com.quadcore.voiceandtext.common.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "analysis_results")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnalysisResult extends BaseTimeEntity {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionType textEmotion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionType voiceEmotion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionType finalEmotion;
+
+    @Column(nullable = false)
+    private Double textEmotionScore;
+
+    @Column(nullable = false)
+    private Double voiceEmotionScore;
+
+    @Column(nullable = false)
+    private Double mismatchScore;
+
+    @Column(columnDefinition = "TEXT")
+    private String summaryExplanation;
+
+    @Column(columnDefinition = "TEXT")
+    private String detailedAnalysis;
+
+    @Column
+    private Long processingTimeMs;
 }

--- a/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisTimelineSegment.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisTimelineSegment.java
@@ -1,5 +1,33 @@
 package com.quadcore.voiceandtext.domain.analysis;
 
-public class AnalysisTimelineSegment {
-    // TODO: analysis timeline segment fields
+import com.quadcore.voiceandtext.common.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "analysis_timeline_segments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnalysisTimelineSegment extends BaseTimeEntity {
+    @Column(nullable = false)
+    private Integer startTimeMs;
+
+    @Column(nullable = false)
+    private Integer endTimeMs;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionType detectedEmotion;
+
+    @Column(nullable = false)
+    private Double emotionScore;
+
+    @Column(columnDefinition = "TEXT")
+    private String transcriptionSegment;
+
+    @Column(nullable = false)
+    private Long analysisResultId;
 }

--- a/src/main/java/com/quadcore/voiceandtext/domain/analysis/Transcription.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/analysis/Transcription.java
@@ -1,5 +1,29 @@
 package com.quadcore.voiceandtext.domain.analysis;
 
-public class Transcription {
-    // TODO: transcription fields
+import com.quadcore.voiceandtext.common.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "transcriptions")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Transcription extends BaseTimeEntity {
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String text;
+
+    @Column(nullable = false)
+    private String language;
+
+    @Column
+    private Double confidence;
+
+    @Column(length = 100)
+    private String transcriptionProvider;
+
+    @Column
+    private Long processingTimeMs;
 }

--- a/src/main/java/com/quadcore/voiceandtext/domain/file/AudioFile.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/file/AudioFile.java
@@ -1,5 +1,43 @@
 package com.quadcore.voiceandtext.domain.file;
 
-public class AudioFile {
-    // TODO: audio file fields
+import com.quadcore.voiceandtext.common.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "audio_files")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AudioFile extends BaseTimeEntity {
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column(nullable = false, unique = true)
+    private String storedFileName;
+
+    @Column(nullable = false)
+    private String fileUrl;
+
+    @Column(nullable = false)
+    private Long fileSizeBytes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FileType fileType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FileSourceType sourceType;
+
+    @Column(length = 50)
+    private String mimeType;
+
+    @Column
+    private Integer durationSeconds;
+
+    @Column(length = 255)
+    private String storageLocation;
 }

--- a/src/main/java/com/quadcore/voiceandtext/domain/user/User.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/user/User.java
@@ -1,5 +1,41 @@
 package com.quadcore.voiceandtext.domain.user;
 
-public class User {
-    // TODO: user fields
+import com.quadcore.voiceandtext.common.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User extends BaseTimeEntity {
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MembershipType membershipType;
+
+    @Column(length = 255)
+    private String profileImageUrl;
+
+    @Column(length = 500)
+    private String bio;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- close #1 

## 📌 개요
<!-- 어떤 작업인지 간단히 설명해주세요. -->
- VoiceAndText 서비스의 도메인 Entity를 설계하고 구현했습니다.
- AnalysisRequest를 중심으로 사용자, 파일, 전사, 분석 결과 간의 관계를 정의했습니다.

## 🔍 작업 내용
<!-- 어떤 변경을 했는지 구체적으로 작성해주세요. -->
- User, AnalysisRequest, AudioFile, Transcription, AnalysisResult Entity 생성
- AnalysisRequest 중심 도메인 구조 설계
- 회원/비회원 처리를 위한 user_id nullable 및 isGuest 필드 적용
- 분석 상태 관리를 위한 enum 추가
- 엔티티 간 연관관계 (1:N, 1:1) 설정
- 공통 BaseEntity / BaseTimeEntity 재사용 (존재 시)

## 🔧 변경 사항
<!-- 주요 변경 파일이나 로직을 정리해주세요. -->
- domain.user.User
- domain.analysis.AnalysisRequest
- domain.file.AudioFile
- domain.analysis.Transcription
- domain.analysis.AnalysisResult
- domain.analysis.enums (AnalysisStatus 등)
- 공통 엔티티(BaseEntity, BaseTimeEntity) 활용

## ⚠️ 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->
- AnalysisRequest 중심 설계가 적절한지
- 엔티티 간 연관관계(특히 1:1 매핑)가 적절한지
- 회원/비회원 처리 방식(user_id nullable + isGuest)이 괜찮은지
- 추후 확장 시 구조적으로 문제 없는지