### PR TITLE
design: 백엔드 초기 화면 안내 페이지 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 HELP.md
 .gradle
 build/

--- a/src/main/resources/static/index.html‎
+++ b/src/main/resources/static/index.html‎
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>V&T | Backend</title>
+    <style>
+        * {
+          margin: 0;
+          padding: 0;
+          box-sizing: border-box;
+          font-family: "Segoe UI", "Noto Sans KR", sans-serif;
+        }
+
+        body {
+          height: 100vh;
+          background: linear-gradient(to right, #f8f9fa, #e9ecef);
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+        .container {
+          background: white;
+          padding: 3rem 4rem;
+          border-radius: 20px;
+          box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+          text-align: center;
+          max-width: 500px;
+        }
+
+        h1 {
+          font-size: 2rem;
+          color: #2c3e50;
+          margin-bottom: 1rem;
+        }
+
+        p {
+          font-size: 1rem;
+          color: #555;
+          margin-bottom: 2.5rem;
+        }
+
+        .btn {
+          display: inline-block;
+          padding: 0.75rem 1.5rem;
+          background-color: #4a90e2;
+          color: white;
+          border: none;
+          border-radius: 30px;
+          font-size: 1rem;
+          cursor: pointer;
+          text-decoration: none;
+          transition: background-color 0.3s ease;
+        }
+
+        .btn:hover {
+          background-color: #357ab7;
+        }
+
+        .logo {
+          font-size: 1.5rem;
+          font-weight: bold;
+          color: #4a90e2;
+          margin-bottom: 1.2rem;
+        }
+
+        .small {
+          font-size: 0.9rem;
+          color: #888;
+          margin-top: 2rem;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="logo">Voice And Text</div>
+    <h1>백엔드 서버에 오신 걸<br /> 환영합니다!</h1>
+    <p>
+        이 페이지는 V&T의 백엔드 API 서버입니다.<br />
+        API 문서를 확인하려면 아래 버튼을 클릭해주세요.
+    </p>
+    <a class="btn" href="/swagger-ui/index.html">📚 Swagger API 문서 보기</a>
+    <div class="small">© 2026 쿼드코어 | Backend Service</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 🔗 관련 이슈
- close #8

## 📌 개요
- 백엔드 서버 접속 시 표시되는 초기 안내 페이지를 추가했습니다.

## 🔍 작업 내용
- `index.html` 정적 페이지 생성
- 백엔드 서버 안내 문구 추가
- Swagger API 문서 이동 버튼 추가
- 간단한 카드 UI 및 반응형 스타일 적용

## 🔧 변경 사항
- `src/main/resources/static/index.html` 생성
- 인라인 CSS를 활용한 초기 화면 스타일 구성
- `/swagger-ui/index.html` 링크 연결

## ⚠️ 리뷰 포인트
- 초기 안내 페이지 UI/문구가 적절한지
- Swagger 경로 연결 방식에 문제 없는지
- 백엔드 기본 화면으로 사용하기에 적절한 구성인지

## 📸 관련 스크린샷
<img width="1280" height="662" alt="image" src="https://github.com/user-attachments/assets/498cb44c-ce45-4420-a6f0-a7d1f93e8c03" />
