### PR TITLE
feat: Swagger 설정 및 인증 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package com.quadcore.voiceandtext.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.Components;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(apiInfo())
+            .components(components());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Voice and Text API")
+            .description("Voice and Text 애플리케이션 REST API 문서")
+            .version("1.0.0")
+            .contact(new Contact()
+                .name("Quadcore")
+                .url("https://quadcore.com")
+                .email("support@quadcore.com"));
+    }
+
+    private Components components() {
+        Components components = new Components();
+        
+        // Bearer Token 스키마 정의
+        components.addSecuritySchemes("bearer-jwt",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description("JWT Access Token을 사용한 인증\n\nExample: Bearer {accessToken}"));
+        
+        return components;
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/config/SwaggerConfig.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.Components;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/quadcore/voiceandtext/presentation/auth/AuthController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/auth/AuthController.java
@@ -13,10 +13,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
+@Tag(name = "Auth", description = "인증 관련 API")
 public class AuthController {
 
     private final AuthService authService;
@@ -29,6 +36,13 @@ public class AuthController {
      * 카카오 로그인/회원가입
      */
     @PostMapping("/kakao-login")
+    @Operation(summary = "카카오 로그인/회원가입", description = "카카오 액세스 토큰을 사용하여 로그인 또는 회원가입합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인/회원가입 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 - 액세스 토큰이 없거나 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     public ResponseEntity<ApiResponse<AuthResponse>> kakaoLogin(
             @Valid @RequestBody KakaoLoginRequest request) {
         AuthResponse response = authService.kakaoLogin(request.getAccessToken());
@@ -39,6 +53,13 @@ public class AuthController {
      * Access Token 재발급
      */
     @PostMapping("/token-refresh")
+    @Operation(summary = "Access Token 재발급", description = "Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenRefreshResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 - Refresh Token이 없거나 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     public ResponseEntity<ApiResponse<TokenRefreshResponse>> refreshAccessToken(
             @Valid @RequestBody TokenRefreshRequest request) {
         TokenRefreshResponse response = authService.refreshAccessToken(request.getRefreshToken());
@@ -49,6 +70,13 @@ public class AuthController {
      * 로그아웃
      */
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "현재 사용자를 로그아웃합니다. 인증이 필요합니다.")
+    @SecurityRequirement(name = "bearer-jwt")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 유효한 토큰이 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal Long userId) {
         if (userId == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
@@ -61,6 +89,13 @@ public class AuthController {
      * 회원탈퇴
      */
     @DeleteMapping("/withdraw")
+    @Operation(summary = "회원탈퇴", description = "현재 사용자의 계정을 탈퇴합니다. 인증이 필요합니다.")
+    @SecurityRequirement(name = "bearer-jwt")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원탈퇴 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 유효한 토큰이 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     public ResponseEntity<ApiResponse<Void>> withdraw(@AuthenticationPrincipal Long userId) {
         if (userId == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");

--- a/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/AuthResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/AuthResponse.java
@@ -4,16 +4,29 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "인증 응답 DTO")
 public class AuthResponse {
+    @Schema(description = "사용자 ID", example = "1")
     private Long userId;
+    
+    @Schema(description = "사용자 이메일", example = "user@example.com")
     private String email;
+    
+    @Schema(description = "사용자 이름", example = "John Doe")
     private String name;
+    
+    @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String accessToken;
+    
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String refreshToken;
+    
+    @Schema(description = "토큰 타입", example = "Bearer")
     private String tokenType;
 }

--- a/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/KakaoLoginRequest.java
@@ -5,12 +5,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "카카오 로그인 요청 DTO")
 public class KakaoLoginRequest {
     @NotBlank(message = "Access token cannot be null or blank")
+    @Schema(description = "카카오 Access Token", example = "ey1234567890abcdefg...")
     private String accessToken;
 }

--- a/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/TokenRefreshRequest.java
@@ -5,12 +5,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "토큰 재발급 요청 DTO")
 public class TokenRefreshRequest {
     @NotBlank(message = "Refresh token cannot be null or blank")
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String refreshToken;
 }

--- a/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/TokenRefreshResponse.java
@@ -4,13 +4,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "토큰 재발급 응답 DTO")
 public class TokenRefreshResponse {
+    @Schema(description = "새로운 Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String accessToken;
+    
+    @Schema(description = "토큰 타입", example = "Bearer")
     private String tokenType;
+    
+    @Schema(description = "토큰 만료 시간 (초)", example = "3600")
     private long expiresIn;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

* close #10 

## 📌 개요

* Swagger(OpenAPI) 설정 추가 및 인증 API 문서화 작업을 진행했습니다.
* Swagger UI 접근 환경을 구성하고 인증 관련 API에 문서화를 적용했습니다.

## 🔍 작업 내용

* Springdoc OpenAPI 의존성 추가
* Swagger UI 설정 및 `/swagger-ui/index.html` 접근 가능하도록 구성
* Security 설정에서 Swagger 관련 경로 비회원 접근 허용
* 인증(Auth) API Swagger 문서화 적용
* Request/Response DTO에 example 및 schema 정보 추가
* API 응답 코드 및 설명 추가

## 🔧 변경 사항

* `build.gradle`

  * Springdoc OpenAPI 의존성 추가
* `SwaggerConfig`

  * OpenAPI 기본 설정 및 JWT Bearer 인증 설정 추가
* `SecurityConfig`

  * Swagger 관련 경로 permitAll 설정
* `AuthController`

  * `@Tag`, `@Operation`, `@ApiResponses` 적용
* 인증 관련 DTO

  * `@Schema`, example 추가

## ⚠️ 리뷰 포인트

* Swagger UI 접근 경로(`/swagger-ui/index.html`) 정상 동작 여부
* JWT Bearer 인증 설정 정상 적용 여부
* 인증 API 문서화 내용 및 응답 예시 적절성
* Security 설정 변경으로 인한 권한 이슈 여부
