### PR TITLE
feat: 카카오 로그인 Authorization Code Flow 적용

### DIFF
--- a/src/main/java/com/quadcore/voiceandtext/application/auth/AuthService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/auth/AuthService.java
@@ -38,9 +38,9 @@ public class AuthService {
     /**
      * Kakao OAuth 로그인/회원가입
      */
-    public AuthResponse kakaoLogin(String kakaoAccessToken) {
+    public AuthResponse kakaoLogin(String authorizationCode) {
         // Kakao에서 사용자 정보 조회
-        KakaoUserInfoResponse kakaoUserInfo = kakaoOAuthService.getUserInfo(kakaoAccessToken);
+        KakaoUserInfoResponse kakaoUserInfo = kakaoOAuthService.getUserInfoByCode(authorizationCode);
 
         if (kakaoUserInfo.getKakaoId() == null) {
             throw new BusinessException(

--- a/src/main/java/com/quadcore/voiceandtext/application/auth/AuthService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/auth/AuthService.java
@@ -5,7 +5,7 @@ import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import com.quadcore.voiceandtext.domain.user.User;
 import com.quadcore.voiceandtext.domain.user.UserRole;
 import com.quadcore.voiceandtext.domain.user.UserStatus;
-import com.quadcore.voiceandtext.infrastructure.oauth.KakaoOAuthService;
+import com.quadcore.voiceandtext.application.oauth.KakaoUserInfoPort;
 import com.quadcore.voiceandtext.infrastructure.oauth.KakaoUserInfoResponse;
 import com.quadcore.voiceandtext.infrastructure.security.JwtTokenProvider;
 import com.quadcore.voiceandtext.presentation.auth.dto.AuthResponse;
@@ -21,16 +21,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final UserRepository userRepository;
-    private final KakaoOAuthService kakaoOAuthService;
+    private final KakaoUserInfoPort kakaoUserInfoPort;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenService tokenService;
 
     public AuthService(UserRepository userRepository,
-                       KakaoOAuthService kakaoOAuthService,
+                       KakaoUserInfoPort kakaoUserInfoPort,
                        JwtTokenProvider jwtTokenProvider,
                        TokenService tokenService) {
         this.userRepository = userRepository;
-        this.kakaoOAuthService = kakaoOAuthService;
+        this.kakaoUserInfoPort = kakaoUserInfoPort;
         this.jwtTokenProvider = jwtTokenProvider;
         this.tokenService = tokenService;
     }
@@ -40,7 +40,7 @@ public class AuthService {
      */
     public AuthResponse kakaoLogin(String authorizationCode) {
         // Kakao에서 사용자 정보 조회
-        KakaoUserInfoResponse kakaoUserInfo = kakaoOAuthService.getUserInfoByCode(authorizationCode);
+        KakaoUserInfoResponse kakaoUserInfo = kakaoUserInfoPort.getUserInfoByCode(authorizationCode);
 
         if (kakaoUserInfo.getKakaoId() == null) {
             throw new BusinessException(

--- a/src/main/java/com/quadcore/voiceandtext/application/oauth/KakaoUserInfoPort.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/oauth/KakaoUserInfoPort.java
@@ -1,0 +1,7 @@
+package com.quadcore.voiceandtext.application.oauth;
+
+import com.quadcore.voiceandtext.infrastructure.oauth.KakaoUserInfoResponse;
+
+public interface KakaoUserInfoPort {
+    KakaoUserInfoResponse getUserInfoByCode(String authorizationCode);
+}

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoOAuthService.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoOAuthService.java
@@ -5,7 +5,10 @@ import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -13,14 +16,88 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class KakaoOAuthService {
 
+    private final String kakaoClientId;
+    private final String kakaoRedirectUri;
+    private final String kakaoTokenUri;
     private final String kakaoUserInfoUri;
     private final RestTemplate restTemplate;
 
     public KakaoOAuthService(
-            @Value("${kakao.oauth.user-info-uri}") String kakaoUserInfoUri,
+            @Value("${kakao.client-id}") String kakaoClientId,
+            @Value("${kakao.redirect-uri}") String kakaoRedirectUri,
+            @Value("${kakao.token-uri}") String kakaoTokenUri,
+            @Value("${kakao.user-info-uri}") String kakaoUserInfoUri,
             RestTemplate restTemplate) {
+        this.kakaoClientId = kakaoClientId;
+        this.kakaoRedirectUri = kakaoRedirectUri;
+        this.kakaoTokenUri = kakaoTokenUri;
         this.kakaoUserInfoUri = kakaoUserInfoUri;
         this.restTemplate = restTemplate;
+    }
+
+    /**
+     * 카카오 인가 코드를 사용하여 액세스 토큰 발급
+     */
+    public String getAccessToken(String authorizationCode) {
+        // 입력 검증
+        if (authorizationCode == null || authorizationCode.isBlank()) {
+            log.warn("Invalid authorization code: code is null or blank");
+            throw new BusinessException(
+                    ErrorCode.INVALID_REQUEST,
+                    "카카오 인가 코드가 유효하지 않습니다."
+            );
+        }
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type", "authorization_code");
+            params.add("client_id", kakaoClientId);
+            params.add("redirect_uri", kakaoRedirectUri);
+            params.add("code", authorizationCode);
+
+            org.springframework.http.HttpEntity<MultiValueMap<String, String>> entity =
+                new org.springframework.http.HttpEntity<>(params, headers);
+
+            org.springframework.http.ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                    kakaoTokenUri,
+                    org.springframework.http.HttpMethod.POST,
+                    entity,
+                    KakaoTokenResponse.class
+            );
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                String accessToken = response.getBody().getAccess_token();
+                if (accessToken == null || accessToken.isBlank()) {
+                    throw new BusinessException(
+                            ErrorCode.UNKNOWN_ERROR,
+                            "카카오에서 액세스 토큰을 받을 수 없습니다."
+                    );
+                }
+                return accessToken;
+            }
+
+            throw new BusinessException(
+                    ErrorCode.UNKNOWN_ERROR,
+                    "카카오 토큰 발급에 실패했습니다."
+            );
+        } catch (RestClientException ex) {
+            log.error("Failed to get access token from Kakao: {}", ex.getMessage());
+            throw new BusinessException(
+                    ErrorCode.UNKNOWN_ERROR,
+                    "카카오 토큰 발급 중 오류가 발생했습니다."
+            );
+        }
+    }
+
+    /**
+     * 카카오 인가 코드를 사용하여 로그인 처리 (토큰 발급 + 사용자 정보 조회)
+     */
+    public KakaoUserInfoResponse getUserInfoByCode(String authorizationCode) {
+        String accessToken = getAccessToken(authorizationCode);
+        return getUserInfo(accessToken);
     }
 
     /**

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoOAuthService.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoOAuthService.java
@@ -11,10 +11,11 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import com.quadcore.voiceandtext.application.oauth.KakaoUserInfoPort;
 
 @Slf4j
 @Service
-public class KakaoOAuthService {
+public class KakaoOAuthService implements KakaoUserInfoPort {
 
     private final String kakaoClientId;
     private final String kakaoRedirectUri;

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoOAuthService.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoOAuthService.java
@@ -4,12 +4,12 @@ import com.quadcore.voiceandtext.common.exception.BusinessException;
 import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import com.quadcore.voiceandtext.application.oauth.KakaoUserInfoPort;
 
@@ -59,12 +59,12 @@ public class KakaoOAuthService implements KakaoUserInfoPort {
             params.add("redirect_uri", kakaoRedirectUri);
             params.add("code", authorizationCode);
 
-            org.springframework.http.HttpEntity<MultiValueMap<String, String>> entity =
-                new org.springframework.http.HttpEntity<>(params, headers);
+            HttpEntity<MultiValueMap<String, String>> entity =
+                new HttpEntity<>(params, headers);
 
-            org.springframework.http.ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
                     kakaoTokenUri,
-                    org.springframework.http.HttpMethod.POST,
+                    HttpMethod.POST,
                     entity,
                     KakaoTokenResponse.class
             );
@@ -84,8 +84,24 @@ public class KakaoOAuthService implements KakaoUserInfoPort {
                     ErrorCode.UNKNOWN_ERROR,
                     "카카오 토큰 발급에 실패했습니다."
             );
+        } catch (RestClientResponseException ex) {
+            HttpStatusCode status = ex.getStatusCode();
+            log.error("Failed to get access token from Kakao: status={}, statusText={}, responseBody={}",
+                    status.value(), status.getClass(), ex.getResponseBodyAsString(), ex);
+
+            if (status.is4xxClientError()) {
+                throw new BusinessException(
+                        ErrorCode.INVALID_REQUEST,
+                        "카카오 인가 코드가 잘못되었거나 토큰 요청이 유효하지 않습니다."
+                );
+            }
+
+            throw new BusinessException(
+                    ErrorCode.UNKNOWN_ERROR,
+                    "카카오 토큰 발급 중 오류가 발생했습니다."
+            );
         } catch (RestClientException ex) {
-            log.error("Failed to get access token from Kakao: {}", ex.getMessage());
+            log.error("Failed to get access token from Kakao: {}", ex.getMessage(), ex);
             throw new BusinessException(
                     ErrorCode.UNKNOWN_ERROR,
                     "카카오 토큰 발급 중 오류가 발생했습니다."

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoTokenResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/oauth/KakaoTokenResponse.java
@@ -1,0 +1,19 @@
+package com.quadcore.voiceandtext.infrastructure.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoTokenResponse {
+    private String token_type;
+    private String access_token;
+    private Integer expires_in;
+    private String refresh_token;
+    private Integer refresh_token_expires_in;
+    private String scope;
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/auth/AuthController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/auth/AuthController.java
@@ -36,16 +36,16 @@ public class AuthController {
      * 카카오 로그인/회원가입
      */
     @PostMapping("/kakao-login")
-    @Operation(summary = "카카오 로그인/회원가입", description = "카카오 액세스 토큰을 사용하여 로그인 또는 회원가입합니다.")
+    @Operation(summary = "카카오 로그인/회원가입", description = "카카오 인가 코드를 사용하여 로그인 또는 회원가입합니다. OAuth2 Authorization Code Flow를 사용합니다.")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인/회원가입 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthResponse.class))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 - 액세스 토큰이 없거나 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 - 인가 코드가 없거나 유효하지 않음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ResponseEntity<ApiResponse<AuthResponse>> kakaoLogin(
             @Valid @RequestBody KakaoLoginRequest request) {
-        AuthResponse response = authService.kakaoLogin(request.getAccessToken());
+        AuthResponse response = authService.kakaoLogin(request.getCode());
         return ResponseEntity.ok(ApiResponse.success("카카오 로그인에 성공했습니다.", response));
     }
 

--- a/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/auth/dto/KakaoLoginRequest.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Builder
 @Schema(description = "카카오 로그인 요청 DTO")
 public class KakaoLoginRequest {
-    @NotBlank(message = "Access token cannot be null or blank")
-    @Schema(description = "카카오 Access Token", example = "ey1234567890abcdefg...")
-    private String accessToken;
+    @NotBlank(message = "Authorization code cannot be null or blank")
+    @Schema(description = "카카오 인가 코드", example = "abc123def456...")
+    private String code;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,12 @@ spring:
   application:
     name: voiceandtext
 
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me
+
 resttemplate:
   connect-timeout: 5000
   read-timeout: 10000


### PR DESCRIPTION
## 🔗 관련 이슈

* close #12 

## 📌 개요

* 카카오 로그인 방식을 기존 Access Token 직접 전달 방식에서 OAuth2 Authorization Code Flow 방식으로 변경했습니다.
* 프론트에서 인가 코드(code)를 전달하면, 백엔드가 카카오 Access Token 발급 및 사용자 조회를 처리하도록 개선했습니다.

## 🔍 작업 내용

* 카카오 로그인 요청 방식을 `accessToken` 기반 → `authorization code` 기반으로 변경
* 카카오 OAuth Token API 연동 추가

  * Authorization Code를 사용하여 Access Token 발급
* 카카오 사용자 정보 조회 로직 유지
* 기존 로그인/회원가입 및 JWT 발급 로직 유지
* Kakao OAuth 관련 설정 분리 (`client-id`, `redirect-uri`, OAuth URI)
* Swagger 요청 형식 변경 (`accessToken` → `code`)
* 카카오 로그인 API 설명 및 예시 수정

## 🔧 변경 사항

* `KakaoOAuthService`

  * 인가 코드 기반 Access Token 발급 로직 구현
  * 카카오 사용자 정보 조회 로직 개선
* 인증 요청 DTO

  * `accessToken` → `code` 기반으로 변경
* `AuthService`

  * Authorization Code Flow 기반 로그인 처리 반영
* `application.yml`

  * Kakao OAuth 설정 값 추가
* Swagger

  * 카카오 로그인 API 요청/설명 변경

## ⚠️ 리뷰 포인트

* Authorization Code → Access Token 발급 흐름 정상 동작 여부
* 카카오 사용자 정보 조회 및 회원가입/로그인 처리 정상 여부
* 기존 JWT 발급 로직 영향 여부
* 카카오 Redirect URI 및 설정값 환경별(local/prod) 차이 검토
