### PR TITLE
feat: 음성 파일 업로드 및 AI 분석 요청 파이프라인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+	implementation 'software.amazon.awssdk:s3:2.20.162'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
@@ -1,0 +1,14 @@
+package com.quadcore.voiceandtext.application.analysis;
+
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface AnalysisRequestRepository {
+    AnalysisRequest save(AnalysisRequest analysisRequest);
+    Optional<AnalysisRequest> findById(Long id);
+    List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(LocalDateTime expiresAt);
+    void delete(AnalysisRequest analysisRequest);
+}

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -25,6 +25,12 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * AnalysisRequest와 guestToken을 함께 반환하는 record
+ * guestToken은 원본 값 (응답에 사용), analysisRequest에는 tokenHash만 저장됨
+ */
+record AnalysisRequestWithToken(AnalysisRequest analysisRequest, String guestToken) {}
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -64,8 +70,10 @@ public class AnalysisService {
         User user = userId != null ? userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)) : null;
 
-        // AnalysisRequest 생성
-        AnalysisRequest analysisRequest = createAnalysisRequest(request, user);
+        // AnalysisRequest 생성 (guestToken 포함)
+        var resultWithToken = createAnalysisRequest(request, user);
+        AnalysisRequest analysisRequest = resultWithToken.analysisRequest();
+        String guestToken = resultWithToken.guestToken();
 
         // AnalysisRequest를 먼저 DB에 저장해서 ID 확정
         AnalysisRequest savedRequest = analysisRequestRepository.save(analysisRequest);
@@ -79,13 +87,13 @@ public class AnalysisService {
         // AudioFile 연결 후 다시 저장
         savedRequest = analysisRequestRepository.save(savedRequest);
 
-        // 응답 생성
+        // 응답 생성 (guestToken이 null이 아니면 포함)
         AudioUploadResponse response = AudioUploadResponse.builder()
                 .analysisRequestId(savedRequest.getId())
-                .guestResultToken(user == null ? generateGuestToken(savedRequest) : null)
+                .guestResultToken(guestToken)
                 .build();
 
-        // AI 서버 요청은 트랜잭션 완료 후 별도로 처리 (비동기 또는 다른 트랜잭션)
+        // AI 서버 요청은 트랜잭션 완료 후 별도로 처리
         requestAnalysisAsync(savedRequest);
 
         return response;
@@ -214,11 +222,16 @@ public class AnalysisService {
         return false;
     }
 
-    private AnalysisRequest createAnalysisRequest(AudioUploadRequest request, User user) {
+    /**
+     * AnalysisRequest와 guestToken을 함께 반환
+     * 비회원의 경우: guestToken 생성 → hash 저장, 원본 token은 record에 포함
+     * 회원의 경우: guestToken = null
+     */
+    private AnalysisRequestWithToken createAnalysisRequest(AudioUploadRequest request, User user) {
         String guestToken = user == null ? UUID.randomUUID().toString() : null;
         String guestTokenHash = guestToken != null ? hashToken(guestToken) : null;
 
-        return AnalysisRequest.builder()
+        AnalysisRequest analysisRequest = AnalysisRequest.builder()
                 .title("음성 분석 요청")
                 .description(request.getContext())
                 .user(user)
@@ -227,15 +240,15 @@ public class AnalysisService {
                 .guestResultTokenHash(guestTokenHash)
                 .expiresAt(user == null ? LocalDateTime.now().plusHours(guestExpiryHours) : null)
                 .build();
+
+        return new AnalysisRequestWithToken(analysisRequest, guestToken);
     }
 
-    private String generateGuestToken(AnalysisRequest request) {
-        // 실제로는 request.getGuestResultTokenHash()에서 복원 로직 필요하지만, 간단히 UUID 사용
-        return UUID.randomUUID().toString();
-    }
-
+    /**
+     * SHA-256를 사용한 토큰 해싱
+     * DB에는 hash만 저장되므로 원본 token은 복구 불가능
+     */
     private String hashToken(String token) {
-        // SHA-256 해싱 (실제 구현에서는 BCrypt 등 사용)
         try {
             java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
             byte[] hash = md.digest(token.getBytes());

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -1,0 +1,119 @@
+package com.quadcore.voiceandtext.application.analysis;
+
+import com.quadcore.voiceandtext.application.auth.UserRepository;
+import com.quadcore.voiceandtext.common.exception.BusinessException;
+import com.quadcore.voiceandtext.common.exception.ErrorCode;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisStatus;
+import com.quadcore.voiceandtext.domain.file.AudioFile;
+import com.quadcore.voiceandtext.domain.user.User;
+import com.quadcore.voiceandtext.infrastructure.analysis.AiService;
+import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadRequest;
+import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalysisService {
+
+    private final AudioUploadService audioUploadService;
+    private final AiService aiService;
+    private final AnalysisRequestRepository analysisRequestRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public AudioUploadResponse uploadAndRequestAnalysis(AudioUploadRequest request, Long userId) {
+        // 파일 검증
+        validateAudioFile(request.getAudio());
+
+        // 사용자 조회 (비회원일 경우 null)
+        User user = userId != null ? userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)) : null;
+
+        // AnalysisRequest 생성
+        AnalysisRequest analysisRequest = createAnalysisRequest(request, user);
+
+        // AudioFile 생성 및 S3 업로드
+        AudioFile audioFile = audioUploadService.uploadAudioFile(request.getAudio(), analysisRequest, request.getSourceType(), request.getDurationSeconds());
+
+        // AnalysisRequest에 AudioFile 연결
+        analysisRequest.setAudioFile(audioFile);
+
+        // 저장
+        AnalysisRequest savedRequest = analysisRequestRepository.save(analysisRequest);
+
+        // AI 서버 요청
+        try {
+            aiService.requestAnalysis(savedRequest);
+            savedRequest.setStatus(AnalysisStatus.PROCESSING);
+        } catch (Exception e) {
+            log.error("AI 서버 요청 실패: {}", e.getMessage());
+            savedRequest.setStatus(AnalysisStatus.FAILED);
+            savedRequest.setErrorMessage("AI 서버 요청 실패: " + e.getMessage());
+        }
+
+        analysisRequestRepository.save(savedRequest);
+
+        // 응답 생성
+        return AudioUploadResponse.builder()
+                .analysisRequestId(savedRequest.getId())
+                .guestResultToken(user == null ? generateGuestToken(savedRequest) : null)
+                .build();
+    }
+
+    private void validateAudioFile(MultipartFile audio) {
+        if (audio.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "빈 파일은 업로드할 수 없습니다.");
+        }
+
+        // 파일 크기 검증 (예: 10MB)
+        if (audio.getSize() > 10 * 1024 * 1024) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+
+        // MIME 타입 검증
+        String contentType = audio.getContentType();
+        if (contentType == null || !contentType.startsWith("audio/")) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "음성 파일만 업로드 가능합니다.");
+        }
+    }
+
+    private AnalysisRequest createAnalysisRequest(AudioUploadRequest request, User user) {
+        String guestToken = user == null ? UUID.randomUUID().toString() : null;
+        String guestTokenHash = guestToken != null ? hashToken(guestToken) : null;
+
+        return AnalysisRequest.builder()
+                .title("음성 분석 요청")
+                .description(request.getContext())
+                .user(user)
+                .isGuest(user == null)
+                .status(AnalysisStatus.PENDING)
+                .guestResultTokenHash(guestTokenHash)
+                .expiresAt(user == null ? LocalDateTime.now().plusHours(24) : null) // 비회원 24시간
+                .build();
+    }
+
+    private String generateGuestToken(AnalysisRequest request) {
+        // 실제로는 request.getGuestResultTokenHash()에서 복원 로직 필요하지만, 간단히 UUID 사용
+        return UUID.randomUUID().toString();
+    }
+
+    private String hashToken(String token) {
+        // SHA-256 해싱 (실제 구현에서는 BCrypt 등 사용)
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(token.getBytes());
+            return java.util.Base64.getEncoder().encodeToString(hash);
+        } catch (Exception e) {
+            throw new RuntimeException("토큰 해싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -13,6 +13,7 @@ import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -47,26 +48,48 @@ public class AnalysisService {
         // AnalysisRequest에 AudioFile 연결
         analysisRequest.setAudioFile(audioFile);
 
-        // 저장
+        // DB에 저장 (트랜잭션 내부)
         AnalysisRequest savedRequest = analysisRequestRepository.save(analysisRequest);
 
-        // AI 서버 요청
-        try {
-            aiService.requestAnalysis(savedRequest);
-            savedRequest.setStatus(AnalysisStatus.PROCESSING);
-        } catch (Exception e) {
-            log.error("AI 서버 요청 실패: {}", e.getMessage());
-            savedRequest.setStatus(AnalysisStatus.FAILED);
-            savedRequest.setErrorMessage("AI 서버 요청 실패: " + e.getMessage());
-        }
-
-        analysisRequestRepository.save(savedRequest);
-
-        // 응답 생성
-        return AudioUploadResponse.builder()
+        // 응답 생성 (트랜잭션 내부에서 ID 필요)
+        AudioUploadResponse response = AudioUploadResponse.builder()
                 .analysisRequestId(savedRequest.getId())
                 .guestResultToken(user == null ? generateGuestToken(savedRequest) : null)
                 .build();
+
+        // AI 서버 요청은 트랜잭션 완료 후 별도로 처리 (비동기 또는 다른 트랜잭션)
+        requestAnalysisAsync(savedRequest);
+
+        return response;
+    }
+
+    /**
+     * AI 서버 요청을 트랜잭션 외부에서 처리
+     */
+    private void requestAnalysisAsync(AnalysisRequest analysisRequest) {
+        try {
+            aiService.requestAnalysis(analysisRequest);
+            updateAnalysisStatusAfterAiRequest(analysisRequest.getId(), AnalysisStatus.PROCESSING, null);
+        } catch (Exception e) {
+            log.error("AI 서버 요청 실패. analysisRequestId={}", analysisRequest.getId(), e);
+            updateAnalysisStatusAfterAiRequest(analysisRequest.getId(), AnalysisStatus.FAILED, "AI 서버 요청 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 분석 상태 업데이트 (REQUIRES_NEW로 새로운 트랜잭션 생성)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateAnalysisStatusAfterAiRequest(Long analysisRequestId, AnalysisStatus status, String errorMessage) {
+        AnalysisRequest analysisRequest = analysisRequestRepository.findById(analysisRequestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "분석 요청을 찾을 수 없습니다."));
+        
+        analysisRequest.setStatus(status);
+        if (errorMessage != null) {
+            analysisRequest.setErrorMessage(errorMessage);
+        }
+        
+        analysisRequestRepository.save(analysisRequest);
     }
 
     private void validateAudioFile(MultipartFile audio) {

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -12,12 +12,17 @@ import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadRequest;
 import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -30,10 +35,30 @@ public class AnalysisService {
     private final AnalysisRequestRepository analysisRequestRepository;
     private final UserRepository userRepository;
 
+    @Value("${app.audio.max-file-size:10485760}") // 10MB
+    private long maxFileSize;
+
+    @Value("${app.audio.max-duration-seconds:60}")
+    private int maxDurationSeconds;
+
+    @Value("${app.guest.expiry-hours:24}")
+    private int guestExpiryHours;
+
+    @Value("${app.audio.allowed-mime-types:audio/mpeg,audio/wav,audio/ogg,audio/webm,audio/mp4}")
+    private String allowedMimeTypesStr;
+
+    private Set<String> allowedMimeTypes;
+
+    private void initAllowedMimeTypes() {
+        if (allowedMimeTypes == null) {
+            allowedMimeTypes = new HashSet<>(Arrays.asList(allowedMimeTypesStr.split("\\s*,\\s*")));
+        }
+    }
+
     @Transactional
     public AudioUploadResponse uploadAndRequestAnalysis(AudioUploadRequest request, Long userId) {
-        // 파일 검증
-        validateAudioFile(request.getAudio());
+        // 파일 및 duration 검증
+        validateAudioFile(request.getAudio(), request.getDurationSeconds());
 
         // 사용자 조회 (비회원일 경우 null)
         User user = userId != null ? userRepository.findById(userId)
@@ -95,21 +120,98 @@ public class AnalysisService {
         analysisRequestRepository.save(analysisRequest);
     }
 
-    private void validateAudioFile(MultipartFile audio) {
+    private void validateAudioFile(MultipartFile audio, Integer durationSeconds) {
+        initAllowedMimeTypes();
+
         if (audio.isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST, "빈 파일은 업로드할 수 없습니다.");
         }
 
-        // 파일 크기 검증 (예: 10MB)
-        if (audio.getSize() > 10 * 1024 * 1024) {
-            throw new BusinessException(ErrorCode.INVALID_REQUEST, "파일 크기는 10MB를 초과할 수 없습니다.");
+        // Duration 검증
+        if (durationSeconds == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "녹음 시간이 필요합니다.");
+        }
+        if (durationSeconds <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "녹음 시간은 0초보다 커야 합니다.");
+        }
+        if (durationSeconds > maxDurationSeconds) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "녹음 시간은 " + maxDurationSeconds + "초 이하여야 합니다.");
         }
 
-        // MIME 타입 검증
-        String contentType = audio.getContentType();
-        if (contentType == null || !contentType.startsWith("audio/")) {
-            throw new BusinessException(ErrorCode.INVALID_REQUEST, "음성 파일만 업로드 가능합니다.");
+        // 파일 크기 검증
+        if (audio.getSize() > maxFileSize) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "파일 크기는 " + (maxFileSize / (1024 * 1024)) + "MB를 초과할 수 없습니다.");
         }
+
+        // MIME 타입 검증 (화이트리스트)
+        String contentType = audio.getContentType();
+        if (contentType == null || !allowedMimeTypes.contains(contentType)) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "지원하지 않는 파일 형식입니다. 지원 형식: " + String.join(", ", allowedMimeTypes));
+        }
+
+        // Magic bytes 검증
+        validateAudioMagicBytes(audio);
+    }
+
+    /**
+     * 파일의 실제 음성 파일 여부를 magic bytes로 검증
+     */
+    private void validateAudioMagicBytes(MultipartFile audio) {
+        try {
+            byte[] fileBytes = audio.getBytes();
+            if (fileBytes.length < 4) {
+                throw new BusinessException(ErrorCode.INVALID_REQUEST, "파일이 너무 작아 유효한 음성 파일이 아닙니다.");
+            }
+
+            // 음성 파일 매직 바이트 검증
+            // MP3: 0xFF 0xFB or 0xFF 0xFA (MPEG-1/2 Layer III)
+            // WAV: 0x52 0x49 0x46 0x46 ("RIFF")
+            // OGG: 0x4F 0x67 0x67 0x53 ("OggS")
+            // MP4/M4A: 0x66 0x74 0x79 0x70 at offset 4 ("ftyp")
+            // WebM: 0x1A 0x45 0xDF 0xA3
+            boolean isValidMagicBytes = isValidAudioMagicBytes(fileBytes);
+            if (!isValidMagicBytes) {
+                throw new BusinessException(ErrorCode.INVALID_REQUEST, "파일이 유효한 음성 파일이 아닙니다. 다시 확인해주세요.");
+            }
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "파일 검증 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * Magic bytes를 확인하여 실제 음성 파일인지 검증
+     */
+    private boolean isValidAudioMagicBytes(byte[] fileBytes) {
+        if (fileBytes.length < 4) {
+            return false;
+        }
+
+        // MP3 (0xFF 0xFB or 0xFF 0xFA)
+        if ((fileBytes[0] == (byte) 0xFF && (fileBytes[1] == (byte) 0xFB || fileBytes[1] == (byte) 0xFA))) {
+            return true;
+        }
+
+        // WAV ("RIFF" = 0x52 0x49 0x46 0x46)
+        if (fileBytes[0] == 0x52 && fileBytes[1] == 0x49 && fileBytes[2] == 0x46 && fileBytes[3] == 0x46) {
+            return true;
+        }
+
+        // OGG ("OggS" = 0x4F 0x67 0x67 0x53)
+        if (fileBytes[0] == 0x4F && fileBytes[1] == 0x67 && fileBytes[2] == 0x67 && fileBytes[3] == 0x53) {
+            return true;
+        }
+
+        // WebM (0x1A 0x45 0xDF 0xA3)
+        if (fileBytes[0] == (byte) 0x1A && fileBytes[1] == 0x45 && fileBytes[2] == (byte) 0xDF && fileBytes[3] == (byte) 0xA3) {
+            return true;
+        }
+
+        // MP4/M4A ("ftyp" at offset 4)
+        if (fileBytes.length >= 8 && fileBytes[4] == 0x66 && fileBytes[5] == 0x74 && fileBytes[6] == 0x79 && fileBytes[7] == 0x70) {
+            return true;
+        }
+
+        return false;
     }
 
     private AnalysisRequest createAnalysisRequest(AudioUploadRequest request, User user) {
@@ -123,7 +225,7 @@ public class AnalysisService {
                 .isGuest(user == null)
                 .status(AnalysisStatus.PENDING)
                 .guestResultTokenHash(guestTokenHash)
-                .expiresAt(user == null ? LocalDateTime.now().plusHours(24) : null) // 비회원 24시간
+                .expiresAt(user == null ? LocalDateTime.now().plusHours(guestExpiryHours) : null)
                 .build();
     }
 

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -42,16 +42,19 @@ public class AnalysisService {
         // AnalysisRequest 생성
         AnalysisRequest analysisRequest = createAnalysisRequest(request, user);
 
-        // AudioFile 생성 및 S3 업로드
-        AudioFile audioFile = audioUploadService.uploadAudioFile(request.getAudio(), analysisRequest, request.getSourceType(), request.getDurationSeconds());
-
-        // AnalysisRequest에 AudioFile 연결
-        analysisRequest.setAudioFile(audioFile);
-
-        // DB에 저장 (트랜잭션 내부)
+        // AnalysisRequest를 먼저 DB에 저장해서 ID 확정
         AnalysisRequest savedRequest = analysisRequestRepository.save(analysisRequest);
 
-        // 응답 생성 (트랜잭션 내부에서 ID 필요)
+        // AudioFile 생성 및 S3 업로드 (ID가 확정된 savedRequest 사용)
+        AudioFile audioFile = audioUploadService.uploadAudioFile(request.getAudio(), savedRequest, request.getSourceType(), request.getDurationSeconds());
+
+        // AnalysisRequest에 AudioFile 연결
+        savedRequest.setAudioFile(audioFile);
+
+        // AudioFile 연결 후 다시 저장
+        savedRequest = analysisRequestRepository.save(savedRequest);
+
+        // 응답 생성
         AudioUploadResponse response = AudioUploadResponse.builder()
                 .analysisRequestId(savedRequest.getId())
                 .guestResultToken(user == null ? generateGuestToken(savedRequest) : null)

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
@@ -1,0 +1,64 @@
+package com.quadcore.voiceandtext.application.analysis;
+
+import com.quadcore.voiceandtext.common.exception.BusinessException;
+import com.quadcore.voiceandtext.common.exception.ErrorCode;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.file.AudioFile;
+import com.quadcore.voiceandtext.domain.file.FileSourceType;
+import com.quadcore.voiceandtext.domain.file.FileType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AudioUploadService {
+
+    private final S3Service s3Service;
+
+    public AudioFile uploadAudioFile(MultipartFile audio, AnalysisRequest analysisRequest, FileSourceType sourceType, Integer durationSeconds) {
+        String originalFileName = audio.getOriginalFilename();
+        String storedFileName = generateStoredFileName(analysisRequest, originalFileName);
+        String s3Key = generateS3Key(analysisRequest, storedFileName);
+
+        // S3 업로드
+        String fileUrl = s3Service.uploadFile(audio, s3Key);
+
+        // AudioFile 엔티티 생성
+        return AudioFile.builder()
+                .originalFileName(originalFileName)
+                .storedFileName(storedFileName)
+                .fileUrl(fileUrl)
+                .fileSizeBytes(audio.getSize())
+                .fileType(FileType.AUDIO)
+                .sourceType(sourceType)
+                .mimeType(audio.getContentType())
+                .durationSeconds(durationSeconds)
+                .storageLocation(s3Key)
+                .build();
+    }
+
+    private String generateStoredFileName(AnalysisRequest analysisRequest, String originalFileName) {
+        String extension = getFileExtension(originalFileName);
+        return analysisRequest.getId() + "_" + UUID.randomUUID() + (extension != null ? "." + extension : "");
+    }
+
+    private String generateS3Key(AnalysisRequest analysisRequest, String storedFileName) {
+        if (analysisRequest.getIsGuest()) {
+            return "temp/guest/audio/" + analysisRequest.getId() + "/" + storedFileName;
+        } else {
+            return "members/" + analysisRequest.getUser().getId() + "/audio/" + analysisRequest.getId() + "/" + storedFileName;
+        }
+    }
+
+    private String getFileExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            return null;
+        }
+        return fileName.substring(fileName.lastIndexOf(".") + 1);
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
@@ -6,6 +6,7 @@ import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
 import com.quadcore.voiceandtext.domain.file.AudioFile;
 import com.quadcore.voiceandtext.domain.file.FileSourceType;
 import com.quadcore.voiceandtext.domain.file.FileType;
+import com.quadcore.voiceandtext.infrastructure.analysis.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
@@ -1,12 +1,9 @@
 package com.quadcore.voiceandtext.application.analysis;
 
-import com.quadcore.voiceandtext.common.exception.BusinessException;
-import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
 import com.quadcore.voiceandtext.domain.file.AudioFile;
 import com.quadcore.voiceandtext.domain.file.FileSourceType;
 import com.quadcore.voiceandtext.domain.file.FileType;
-import com.quadcore.voiceandtext.infrastructure.analysis.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,15 +16,15 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AudioUploadService {
 
-    private final S3Service s3Service;
+    private final FileStoragePort fileStoragePort;
 
     public AudioFile uploadAudioFile(MultipartFile audio, AnalysisRequest analysisRequest, FileSourceType sourceType, Integer durationSeconds) {
         String originalFileName = audio.getOriginalFilename();
         String storedFileName = generateStoredFileName(analysisRequest, originalFileName);
         String s3Key = generateS3Key(analysisRequest, storedFileName);
 
-        // S3 업로드
-        String fileUrl = s3Service.uploadFile(audio, s3Key);
+        // 파일 스토리지 업로드
+        String fileUrl = fileStoragePort.uploadFile(audio, s3Key);
 
         // AudioFile 엔티티 생성
         return AudioFile.builder()

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
@@ -53,11 +53,16 @@ public class AudioUploadService {
     }
 
     private String generateS3Key(AnalysisRequest analysisRequest, String storedFileName) {
-        if (analysisRequest.getIsGuest()) {
+        if (Boolean.TRUE.equals(analysisRequest.getIsGuest())) {
             return "temp/guest/audio/" + analysisRequest.getId() + "/" + storedFileName;
-        } else {
-            return "members/" + analysisRequest.getUser().getId() + "/audio/" + analysisRequest.getId() + "/" + storedFileName;
         }
+
+        if (analysisRequest.getUser() == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST,
+                    "Non-guest AnalysisRequest must have a user before generating S3 key.");
+        }
+
+        return "members/" + analysisRequest.getUser().getId() + "/audio/" + analysisRequest.getId() + "/" + storedFileName;
     }
 
     private String getFileExtension(String fileName) {

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AudioUploadService.java
@@ -1,5 +1,7 @@
 package com.quadcore.voiceandtext.application.analysis;
 
+import com.quadcore.voiceandtext.common.exception.BusinessException;
+import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
 import com.quadcore.voiceandtext.domain.file.AudioFile;
 import com.quadcore.voiceandtext.domain.file.FileSourceType;
@@ -19,6 +21,11 @@ public class AudioUploadService {
     private final FileStoragePort fileStoragePort;
 
     public AudioFile uploadAudioFile(MultipartFile audio, AnalysisRequest analysisRequest, FileSourceType sourceType, Integer durationSeconds) {
+        if (analysisRequest.getId() == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST,
+                    "AnalysisRequest id must be assigned before calling uploadAudioFile. Persist the AnalysisRequest first before uploading the audio file.");
+        }
+
         String originalFileName = audio.getOriginalFilename();
         String storedFileName = generateStoredFileName(analysisRequest, originalFileName);
         String s3Key = generateS3Key(analysisRequest, storedFileName);

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/FileStoragePort.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/FileStoragePort.java
@@ -1,0 +1,10 @@
+package com.quadcore.voiceandtext.application.analysis;
+
+import org.springframework.web.multipart.MultipartFile;
+import java.time.Duration;
+
+public interface FileStoragePort {
+    String uploadFile(MultipartFile file, String key);
+    String generatePresignedUrl(String key, Duration expiration);
+    void deleteFile(String key);
+}

--- a/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
@@ -6,7 +6,8 @@ public enum ErrorCode {
     RESOURCE_NOT_FOUND("RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
     UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN("FORBIDDEN", "접근이 거부되었습니다."),
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
+    USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN("FORBIDDEN", "접근이 거부되었습니다."),
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
-    USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    INVALID_FILE_SOURCE_TYPE("INVALID_FILE_SOURCE_TYPE", "sourceType은 UPLOAD 또는 RECORD만 가능합니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisRequest.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisRequest.java
@@ -53,6 +53,12 @@ public class AnalysisRequest extends BaseTimeEntity {
     @Column
     private Integer priority;
 
+    @Column(length = 255)
+    private String guestResultTokenHash;
+
+    @Column
+    private java.time.LocalDateTime expiresAt;
+
     @Column(columnDefinition = "TEXT")
     private String errorMessage;
 }

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/AiService.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/AiService.java
@@ -1,0 +1,56 @@
+package com.quadcore.voiceandtext.infrastructure.analysis;
+
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiService {
+
+    private final RestTemplate restTemplate;
+    private final S3Service s3Service;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    @Value("${ai.server.timeout}")
+    private int timeout;
+
+    public void requestAnalysis(AnalysisRequest analysisRequest) {
+        String presignedUrl = s3Service.generatePresignedUrl(analysisRequest.getAudioFile().getStorageLocation(), Duration.ofMinutes(10));
+
+        Map<String, Object> requestBody = Map.of(
+                "analysisRequestId", analysisRequest.getId(),
+                "audioUrl", presignedUrl,
+                "durationSeconds", analysisRequest.getAudioFile().getDurationSeconds()
+                // callbackUrl은 나중에 추가
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                aiServerUrl + "/api/analyze",
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new RuntimeException("AI 서버 요청 실패: " + response.getStatusCode());
+        }
+
+        log.info("AI 서버 요청 성공: {}", analysisRequest.getId());
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/AiService.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/AiService.java
@@ -1,9 +1,11 @@
 package com.quadcore.voiceandtext.infrastructure.analysis;
 
 import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -16,7 +18,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AiService {
 
-    private final RestTemplate restTemplate;
+    private final RestTemplateBuilder restTemplateBuilder;
+    private RestTemplate restTemplate;
     private final S3Service s3Service;
 
     @Value("${ai.server.url}")
@@ -24,6 +27,14 @@ public class AiService {
 
     @Value("${ai.server.timeout}")
     private int timeout;
+
+    @PostConstruct
+    private void init() {
+        this.restTemplate = restTemplateBuilder
+                .setConnectTimeout(Duration.ofMillis(timeout))
+                .setReadTimeout(Duration.ofMillis(timeout))
+                .build();
+    }
 
     public void requestAnalysis(AnalysisRequest analysisRequest) {
         String presignedUrl = s3Service.generatePresignedUrl(analysisRequest.getAudioFile().getStorageLocation(), Duration.ofMinutes(10));

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/GuestFileCleanupScheduler.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/GuestFileCleanupScheduler.java
@@ -1,0 +1,44 @@
+package com.quadcore.voiceandtext.infrastructure.analysis;
+
+import com.quadcore.voiceandtext.application.analysis.AnalysisRequestRepository;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GuestFileCleanupScheduler {
+
+    private final AnalysisRequestRepository analysisRequestRepository;
+    private final S3Service s3Service;
+
+    @Scheduled(fixedRateString = "${app.cleanup.interval:3600000}") // 기본 1시간
+    @Transactional
+    public void cleanupExpiredGuestFiles() {
+        LocalDateTime now = LocalDateTime.now();
+        List<AnalysisRequest> expiredRequests = analysisRequestRepository.findByIsGuestTrueAndExpiresAtBefore(now);
+
+        for (AnalysisRequest request : expiredRequests) {
+            try {
+                // S3 파일 삭제
+                if (request.getAudioFile() != null) {
+                    s3Service.deleteFile(request.getAudioFile().getStorageLocation());
+                }
+
+                // DB에서 삭제 또는 만료 처리
+                analysisRequestRepository.delete(request);
+
+                log.info("만료된 비회원 파일 삭제: {}", request.getId());
+            } catch (Exception e) {
+                log.error("비회원 파일 삭제 실패: {}", request.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
@@ -1,0 +1,60 @@
+package com.quadcore.voiceandtext.infrastructure.analysis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file, String key) {
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(putObjectRequest,
+                    software.amazon.awssdk.core.sync.RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            log.info("파일 업로드 성공: {}", key);
+            return "https://" + bucketName + ".s3.amazonaws.com/" + key;
+
+        } catch (S3Exception | IOException e) {
+            log.error("S3 업로드 실패: {}", e.getMessage());
+            throw new RuntimeException("파일 업로드 실패", e);
+        }
+    }
+
+    public String generatePresignedUrl(String key, Duration expiration) {
+        // Presigned URL 생성 로직 (필요시 구현)
+        return "https://" + bucketName + ".s3.amazonaws.com/" + key;
+    }
+
+    public void deleteFile(String key) {
+        try {
+            s3Client.deleteObject(builder -> builder.bucket(bucketName).key(key));
+            log.info("파일 삭제 성공: {}", key);
+        } catch (S3Exception e) {
+            log.error("S3 삭제 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
@@ -8,6 +8,9 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.io.IOException;
 import java.net.URL;
@@ -19,6 +22,7 @@ import java.time.Duration;
 public class S3Service {
 
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
 
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
@@ -45,8 +49,18 @@ public class S3Service {
     }
 
     public String generatePresignedUrl(String key, Duration expiration) {
-        // Presigned URL 생성 로직 (필요시 구현)
-        return "https://" + bucketName + ".s3.amazonaws.com/" + key;
+        // Presigned URL 생성 로직
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(expiration)
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 
     public void deleteFile(String key) {

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
+import com.quadcore.voiceandtext.application.analysis.FileStoragePort;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -13,13 +14,12 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.io.IOException;
-import java.net.URL;
 import java.time.Duration;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class S3Service {
+public class S3Service implements FileStoragePort {
 
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/S3Service.java
@@ -69,6 +69,7 @@ public class S3Service {
             log.info("파일 삭제 성공: {}", key);
         } catch (S3Exception e) {
             log.error("S3 삭제 실패: {}", e.getMessage());
+            throw new RuntimeException("Failed to delete S3 object: " + key, e);
         }
     }
 }

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/config/S3Config.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/config/S3Config.java
@@ -3,8 +3,7 @@ package com.quadcore.voiceandtext.infrastructure.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -14,19 +13,12 @@ public class S3Config {
     @Value("${aws.s3.region}")
     private String region;
 
-    @Value("${aws.s3.access-key}")
-    private String accessKey;
-
-    @Value("${aws.s3.secret-key}")
-    private String secretKey;
-
     @Bean
     public S3Client s3Client() {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/config/S3Config.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.quadcore.voiceandtext.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/config/S3Config.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -17,6 +18,14 @@ public class S3Config {
     public S3Client s3Client() {
 
         return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
@@ -1,0 +1,47 @@
+package com.quadcore.voiceandtext.infrastructure.persistence;
+
+import com.quadcore.voiceandtext.application.analysis.AnalysisRequestRepository;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+interface SpringDataAnalysisRequestJpaRepository extends JpaRepository<AnalysisRequest, Long> {
+    @Query("SELECT ar FROM AnalysisRequest ar WHERE ar.isGuest = true AND ar.expiresAt < :expiresAt")
+    List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(@Param("expiresAt") LocalDateTime expiresAt);
+}
+
+@Component
+public class JpaAnalysisRequestRepository implements AnalysisRequestRepository {
+
+    private final SpringDataAnalysisRequestJpaRepository springDataRepository;
+
+    public JpaAnalysisRequestRepository(SpringDataAnalysisRequestJpaRepository springDataRepository) {
+        this.springDataRepository = springDataRepository;
+    }
+
+    @Override
+    public AnalysisRequest save(AnalysisRequest analysisRequest) {
+        return springDataRepository.save(analysisRequest);
+    }
+
+    @Override
+    public Optional<AnalysisRequest> findById(Long id) {
+        return springDataRepository.findById(id);
+    }
+
+    @Override
+    public List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(LocalDateTime expiresAt) {
+        return springDataRepository.findByIsGuestTrueAndExpiresAtBefore(expiresAt);
+    }
+
+    @Override
+    public void delete(AnalysisRequest analysisRequest) {
+        springDataRepository.delete(analysisRequest);
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/analysis/AnalysisController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/analysis/AnalysisController.java
@@ -1,0 +1,45 @@
+package com.quadcore.voiceandtext.presentation.analysis;
+
+import com.quadcore.voiceandtext.application.analysis.AnalysisService;
+import com.quadcore.voiceandtext.common.response.ApiResponse;
+import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadRequest;
+import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/analysis")
+@Tag(name = "Analysis", description = "음성 분석 관련 API")
+@RequiredArgsConstructor
+public class AnalysisController {
+
+    private final AnalysisService analysisService;
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "음성 파일 업로드 및 분석 요청", description = "음성 파일을 업로드하고 분석을 요청합니다. 회원/비회원 모두 가능합니다.")
+    public ResponseEntity<ApiResponse<AudioUploadResponse>> uploadAudio(
+            @RequestParam("audio") MultipartFile audio,
+            @RequestParam("sourceType") String sourceType,
+            @RequestParam("durationSeconds") Integer durationSeconds,
+            @RequestParam(value = "context", required = false) String context,
+            @AuthenticationPrincipal Long userId) {
+
+        AudioUploadRequest request = AudioUploadRequest.builder()
+                .audio(audio)
+                .sourceType(com.quadcore.voiceandtext.domain.file.FileSourceType.valueOf(sourceType.toUpperCase()))
+                .durationSeconds(durationSeconds)
+                .context(context)
+                .build();
+
+        AudioUploadResponse response = analysisService.uploadAndRequestAnalysis(request, userId);
+        return ResponseEntity.ok(ApiResponse.success("음성 분석 요청이 접수되었습니다.", response));
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/analysis/AnalysisController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/analysis/AnalysisController.java
@@ -1,7 +1,10 @@
 package com.quadcore.voiceandtext.presentation.analysis;
 
 import com.quadcore.voiceandtext.application.analysis.AnalysisService;
+import com.quadcore.voiceandtext.common.exception.BusinessException;
+import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import com.quadcore.voiceandtext.common.response.ApiResponse;
+import com.quadcore.voiceandtext.domain.file.FileSourceType;
 import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadRequest;
 import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,19 +25,30 @@ import org.springframework.web.multipart.MultipartFile;
 public class AnalysisController {
 
     private final AnalysisService analysisService;
+    private FileSourceType parseSourceType(String sourceType) {
+        if (sourceType == null || sourceType.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_SOURCE_TYPE);
+        }
+
+        try {
+            return FileSourceType.valueOf(sourceType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_SOURCE_TYPE);
+        }
+    }
 
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "음성 파일 업로드 및 분석 요청", description = "음성 파일을 업로드하고 분석을 요청합니다. 회원/비회원 모두 가능합니다.")
     public ResponseEntity<ApiResponse<AudioUploadResponse>> uploadAudio(
             @RequestParam("audio") MultipartFile audio,
-            @RequestParam("sourceType") String sourceType,
+            @RequestParam("sourceType") FileSourceType sourceType,
             @RequestParam("durationSeconds") Integer durationSeconds,
             @RequestParam(value = "context", required = false) String context,
             @AuthenticationPrincipal Long userId) {
 
         AudioUploadRequest request = AudioUploadRequest.builder()
                 .audio(audio)
-                .sourceType(com.quadcore.voiceandtext.domain.file.FileSourceType.valueOf(sourceType.toUpperCase()))
+                .sourceType(sourceType)
                 .durationSeconds(durationSeconds)
                 .context(context)
                 .build();

--- a/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AudioUploadRequest.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AudioUploadRequest.java
@@ -1,0 +1,30 @@
+package com.quadcore.voiceandtext.presentation.analysis.dto;
+
+import com.quadcore.voiceandtext.domain.file.FileSourceType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AudioUploadRequest {
+    @NotNull(message = "음성 파일은 필수입니다.")
+    private MultipartFile audio;
+
+    @NotNull(message = "소스 타입은 필수입니다.")
+    private FileSourceType sourceType;
+
+    @NotNull(message = "녹음 시간은 필수입니다.")
+    @Min(value = 1, message = "녹음 시간은 1초 이상이어야 합니다.")
+    @Max(value = 60, message = "녹음 시간은 60초 이하여야 합니다.")
+    private Integer durationSeconds;
+
+    private String context;
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AudioUploadResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AudioUploadResponse.java
@@ -1,0 +1,15 @@
+package com.quadcore.voiceandtext.presentation.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AudioUploadResponse {
+    private Long analysisRequestId;
+    private String guestResultToken; // 비회원일 경우에만 포함
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,3 +11,15 @@ kakao:
 resttemplate:
   connect-timeout: 5000
   read-timeout: 10000
+
+aws:
+  s3:
+    bucket-name: ${AWS_S3_BUCKET_NAME}
+    region: ${AWS_REGION:ap-northeast-2}
+    access-key: ${AWS_ACCESS_KEY_ID}
+    secret-key: ${AWS_SECRET_ACCESS_KEY}
+
+ai:
+  server:
+    url: ${AI_SERVER_URL:http://localhost:8000}
+    timeout: 10000

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,3 +23,13 @@ ai:
   server:
     url: ${AI_SERVER_URL:http://localhost:8000}
     timeout: 10000
+
+app:
+  audio:
+    max-file-size: 10485760 # 10MB
+    max-duration-seconds: 60
+    allowed-mime-types: audio/mpeg,audio/wav,audio/ogg,audio/webm,audio/mp4
+  guest:
+    expiry-hours: 24
+  cleanup:
+    interval: 3600000 # 1시간 (밀리초)


### PR DESCRIPTION
## 🔗 관련 이슈
- close #14 

## 📌 개요
<!-- 어떤 작업인지 간단히 설명해주세요. -->
- 음성 파일 업로드/녹음 기반 분석 요청 API를 구현했습니다.
- 업로드된 음성 파일을 S3에 저장하고, Presigned URL을 통해 AI 서버에 분석 요청을 전달하는 구조를 구성했습니다.
- 회원/비회원 분석 요청 흐름을 모두 지원하며, 비회원은 조회 토큰과 만료/삭제 정책을 적용했습니다.

## 🔍 작업 내용
<!-- 어떤 변경을 했는지 구체적으로 작성해주세요. -->
- `multipart/form-data` 기반 음성 파일 업로드 API 구현
- 업로드 파일 검증 로직 추가
  - 빈 파일 검증
  - content type 검증
  - 파일 크기 제한
  - 1분 이내 duration 검증
- 회원/비회원 분석 요청 생성 흐름 구현
  - 회원: JWT 기반 사용자 식별 후 `AnalysisRequest` 연결
  - 비회원: `isGuest=true`, `expiresAt` 설정, `guestResultToken` 발급
- 음성 파일 S3 업로드 기능 구현
- 회원/비회원 S3 저장 경로 분리
  - 회원: `members/{userId}/audio/{analysisRequestId}/{uuid}.{ext}`
  - 비회원: `temp/guest/audio/{analysisRequestId}/{uuid}.{ext}`
- `AudioFile` 메타데이터 저장
  - original filename
  - content type
  - file size
  - S3 key/path
  - duration seconds
- AI 서버 요청 구조 구현
  - Presigned URL 생성
  - `analysisRequestId`, `audioUrl`, `durationSeconds` 전달
  - 요청 성공 시 `PROCESSING`, 실패 시 `FAILED` 상태 반영
- 비회원 결과 조회를 위한 `guestResultToken` 발급 및 hash 저장 구조 추가
- 만료된 비회원 파일 정리를 위한 스케줄러 구현

## 🔧 변경 사항
<!-- 주요 변경 파일이나 로직을 정리해주세요. -->
- `build.gradle`
  - AWS S3 SDK 의존성 추가
- `application.yaml`
  - S3, AI 서버, cleanup 관련 설정 추가
- `AnalysisRequest.java`
  - 비회원 토큰 해시 및 만료 시간 필드 추가
- `AnalysisController.java`
  - 음성 파일 업로드 API 엔드포인트 추가
- `AnalysisService.java`
  - 분석 요청 생성, S3 저장, AI 요청 오케스트레이션 구현
- `AudioUploadService.java`
  - 파일 검증 및 업로드 흐름 분리
- `S3Service.java`
  - S3 파일 업로드/삭제 및 Presigned URL 생성 구현
- `AiService.java`
  - AI 서버 분석 요청 전송 구현
- `GuestFileCleanupScheduler.java`
  - 만료된 비회원 S3 파일 및 DB 데이터 정리
- Repositories / DTOs
  - 분석 요청, 파일 메타데이터, 업로드 응답 구조 지원

## ⚠️ 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->
- 회원/비회원 분석 요청 흐름이 적절하게 분리되어 있는지
- S3 저장 경로 정책이 추후 관리/삭제에 적절한지
- `guestResultToken`을 hash로 저장하는 방식이 적절한지
- AI 서버 요청 실패 시 `FAILED` 상태 처리 방식이 적절한지
- 비회원 만료 파일 삭제 스케줄러의 삭제 범위가 안전한지
- Clean Architecture 관점에서 S3/AI 연동 책임이 적절히 분리되어 있는지

## 🚨 참고 사항
<!-- 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요. -->
- 비회원 결과 조회 API에서 `guestResultToken` 검증 로직은 아직 미구현 상태입니다.
- AI 서버 callback 및 분석 결과 저장 API는 다음 이슈에서 구현 예정입니다.
- Redis 기반 분석 작업 Queue 처리는 이번 범위에서 제외하고, 추후 확장 가능한 구조만 고려했습니다.
- AI 서버는 Presigned URL을 통해 음성 파일을 다운로드한 뒤 Whisper API 및 모델 분석을 수행하는 구조를 전제로 합니다.
- 현재 Presigned URL 만료 시간은 10분으로 설정되어 있습니다.