### PR TITLE
feat: AI 분석 결과 저장 및 상태 완료 처리 구현

### DIFF
--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -124,15 +124,20 @@ public class AnalysisService {
     }
 
     private void saveAnalysisResult(AnalysisRequest analysisRequest, AiAnalysisResponse aiResponse) {
+        if (aiResponse == null || aiResponse.getData() == null || aiResponse.getData().getOverallAnalysis() == null) {
+            throw new RuntimeException("AI 서버 응답에 분석 결과가 없습니다.");
+        }
+
+        Double dissonanceIndex = getDissonanceIndexNullable(aiResponse);
         AnalysisResult analysisResult = AnalysisResult.builder()
-                .textEmotion(EmotionType.NEUTRAL)
-                .voiceEmotion(EmotionType.NEUTRAL)
-                .finalEmotion(EmotionType.NEUTRAL)
-                .textEmotionScore(0.0)
-                .voiceEmotionScore(0.0)
-                .mismatchScore(getDissonanceIndex(aiResponse))
+                .textEmotion(null)
+                .voiceEmotion(null)
+                .finalEmotion(null)
+                .textEmotionScore(null)
+                .voiceEmotionScore(null)
+                .mismatchScore(dissonanceIndex)
                 .primaryEmotion(getPrimaryEmotion(aiResponse))
-                .dissonanceIndex(getDissonanceIndexNullable(aiResponse))
+                .dissonanceIndex(dissonanceIndex)
                 .timeSeriesAnalysis(serializeTimeSeriesAnalysis(aiResponse))
                 .summaryExplanation(aiResponse.getMessage())
                 .build();

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -1,14 +1,19 @@
 package com.quadcore.voiceandtext.application.analysis;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.quadcore.voiceandtext.application.auth.UserRepository;
 import com.quadcore.voiceandtext.common.exception.BusinessException;
 import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisResult;
 import com.quadcore.voiceandtext.domain.analysis.AnalysisStatus;
 import com.quadcore.voiceandtext.domain.analysis.AnalysisType;
+import com.quadcore.voiceandtext.domain.analysis.EmotionType;
 import com.quadcore.voiceandtext.domain.file.AudioFile;
 import com.quadcore.voiceandtext.domain.user.User;
 import com.quadcore.voiceandtext.infrastructure.analysis.AiService;
+import com.quadcore.voiceandtext.infrastructure.analysis.dto.AiAnalysisResponse;
 import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadRequest;
 import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +28,8 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -105,11 +112,65 @@ public class AnalysisService {
      */
     private void requestAnalysisAsync(AnalysisRequest analysisRequest) {
         try {
-            aiService.requestAnalysis(analysisRequest);
+            AiAnalysisResponse aiResponse = aiService.requestAnalysis(analysisRequest);
             updateAnalysisStatusAfterAiRequest(analysisRequest.getId(), AnalysisStatus.PROCESSING, null);
+            saveAnalysisResult(analysisRequest, aiResponse);
+            updateAnalysisStatusAfterAiRequest(analysisRequest.getId(), AnalysisStatus.COMPLETED, null);
         } catch (Exception e) {
-            log.error("AI 서버 요청 실패. analysisRequestId={}", analysisRequest.getId(), e);
-            updateAnalysisStatusAfterAiRequest(analysisRequest.getId(), AnalysisStatus.FAILED, "AI 서버 요청 중 오류가 발생했습니다.");
+            log.error("AI 서버 요청 실패. analysisRequestId={}, message={}", analysisRequest.getId(), e.getMessage(), e);
+            updateAnalysisStatusAfterAiRequest(analysisRequest.getId(), AnalysisStatus.FAILED,
+                    "AI 서버 요청 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    private void saveAnalysisResult(AnalysisRequest analysisRequest, AiAnalysisResponse aiResponse) {
+        AnalysisResult analysisResult = AnalysisResult.builder()
+                .textEmotion(EmotionType.NEUTRAL)
+                .voiceEmotion(EmotionType.NEUTRAL)
+                .finalEmotion(EmotionType.NEUTRAL)
+                .textEmotionScore(0.0)
+                .voiceEmotionScore(0.0)
+                .mismatchScore(getDissonanceIndex(aiResponse))
+                .primaryEmotion(getPrimaryEmotion(aiResponse))
+                .dissonanceIndex(getDissonanceIndexNullable(aiResponse))
+                .timeSeriesAnalysis(serializeTimeSeriesAnalysis(aiResponse))
+                .summaryExplanation(aiResponse.getMessage())
+                .build();
+
+        analysisRequest.setAnalysisResult(analysisResult);
+        analysisRequestRepository.save(analysisRequest);
+        log.info("AI 분석 결과 저장 완료: analysisRequestId={}", analysisRequest.getId());
+    }
+
+    private String getPrimaryEmotion(AiAnalysisResponse aiResponse) {
+        if (aiResponse == null || aiResponse.getData() == null || aiResponse.getData().getOverallAnalysis() == null) {
+            return null;
+        }
+        return aiResponse.getData().getOverallAnalysis().getPrimaryEmotion();
+    }
+
+    private Double getDissonanceIndex(AiAnalysisResponse aiResponse) {
+        Double dissonanceIndex = getDissonanceIndexNullable(aiResponse);
+        return dissonanceIndex != null ? dissonanceIndex : 0.0;
+    }
+
+    private Double getDissonanceIndexNullable(AiAnalysisResponse aiResponse) {
+        if (aiResponse == null || aiResponse.getData() == null || aiResponse.getData().getOverallAnalysis() == null) {
+            return null;
+        }
+        return aiResponse.getData().getOverallAnalysis().getDissonanceIndex();
+    }
+
+    private String serializeTimeSeriesAnalysis(AiAnalysisResponse aiResponse) {
+        if (aiResponse == null || aiResponse.getData() == null || aiResponse.getData().getTimeSeriesAnalysis() == null) {
+            return null;
+        }
+
+        try {
+            return new ObjectMapper().writeValueAsString(aiResponse.getData().getTimeSeriesAnalysis());
+        } catch (JsonProcessingException e) {
+            log.warn("timeSeriesAnalysis JSON 변환 실패: message={}", e.getMessage());
+            return null;
         }
     }
 

--- a/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisResult.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisResult.java
@@ -13,24 +13,24 @@ import lombok.*;
 @Builder
 public class AnalysisResult extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = true)
     private EmotionType textEmotion;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = true)
     private EmotionType voiceEmotion;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = true)
     private EmotionType finalEmotion;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Double textEmotionScore;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Double voiceEmotionScore;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Double mismatchScore;
 
     @Column(length = 255)

--- a/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisResult.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/analysis/AnalysisResult.java
@@ -33,6 +33,15 @@ public class AnalysisResult extends BaseTimeEntity {
     @Column(nullable = false)
     private Double mismatchScore;
 
+    @Column(length = 255)
+    private String primaryEmotion;
+
+    @Column
+    private Double dissonanceIndex;
+
+    @Column(columnDefinition = "TEXT")
+    private String timeSeriesAnalysis;
+
     @Column(columnDefinition = "TEXT")
     private String summaryExplanation;
 

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/AiService.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/AiService.java
@@ -1,6 +1,7 @@
 package com.quadcore.voiceandtext.infrastructure.analysis;
 
 import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.infrastructure.analysis.dto.AiAnalysisResponse;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +39,7 @@ public class AiService {
                 .build();
     }
 
-    public void requestAnalysis(AnalysisRequest analysisRequest) {
+    public AiAnalysisResponse requestAnalysis(AnalysisRequest analysisRequest) {
         String key = null;
         if (analysisRequest.getAudioFile() != null) {
             key = analysisRequest.getAudioFile().getStorageLocation();
@@ -67,20 +68,30 @@ public class AiService {
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
 
         try {
-            ResponseEntity<String> response = restTemplate.exchange(
+            ResponseEntity<AiAnalysisResponse> response = restTemplate.exchange(
                     URI.create(aiServerUrl),
                     HttpMethod.POST,
                     entity,
-                    String.class
+                    AiAnalysisResponse.class
             );
 
-            if (!response.getStatusCode().equals(HttpStatus.OK)) {
+            AiAnalysisResponse aiResponse = response.getBody();
+            if (!response.getStatusCode().equals(HttpStatus.OK) || aiResponse == null) {
                 log.error("AI 서버 요청 실패: analysisRequestId={}, status={}, body={}",
                         analysisRequest.getId(), response.getStatusCodeValue(), response.getBody());
                 throw new RuntimeException("AI 서버 요청 실패: " + response.getStatusCodeValue());
             }
 
+            log.info("AI 서버 응답: analysisRequestId={}, status={}, message={}",
+                    analysisRequest.getId(), aiResponse.getStatus(), aiResponse.getMessage());
+
+            if (!"success".equalsIgnoreCase(aiResponse.getStatus())) {
+                String message = aiResponse.getMessage() == null ? "AI 응답 실패" : aiResponse.getMessage();
+                throw new RuntimeException("AI 서버 응답 실패: " + message);
+            }
+
             log.info("AI 서버 요청 성공: {}", analysisRequest.getId());
+            return aiResponse;
         } catch (HttpStatusCodeException e) {
             log.error("AI 서버 요청 실패: analysisRequestId={}, status={}, responseBody={}",
                     analysisRequest.getId(), e.getRawStatusCode(), e.getResponseBodyAsString(), e);

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/dto/AiAnalysisResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/analysis/dto/AiAnalysisResponse.java
@@ -1,0 +1,32 @@
+package com.quadcore.voiceandtext.infrastructure.analysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class AiAnalysisResponse {
+    private String status;
+    private String message;
+    private DataPayload data;
+
+    @Data
+    public static class DataPayload {
+        @JsonProperty("overall_analysis")
+        private OverallAnalysis overallAnalysis;
+
+        @JsonProperty("time_series_analysis")
+        private List<Map<String, Object>> timeSeriesAnalysis;
+    }
+
+    @Data
+    public static class OverallAnalysis {
+        @JsonProperty("primary_emotion")
+        private String primaryEmotion;
+
+        @JsonProperty("dissonance_index")
+        private Double dissonanceIndex;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

* close #16 

## 📌 개요

<!-- 어떤 작업인지 간단히 설명해주세요. -->

* AI 서버 응답을 DTO로 매핑하여 분석 결과를 DB에 저장하는 로직을 구현했습니다.
* 분석 성공 시 `AnalysisRequest` 상태를 `COMPLETED`로 변경하고, 실패 시 `FAILED` 및 에러 메시지를 저장하도록 처리했습니다.

## 🔍 작업 내용

<!-- 어떤 변경을 했는지 구체적으로 작성해주세요. -->

* AI 서버 응답 DTO(`AiAnalysisResponse`) 추가
* HTTP 200 + `status = success`인 경우에만 성공으로 처리하도록 로직 개선
* AI 분석 결과를 `AnalysisResult` 엔티티에 저장

  * `primaryEmotion`
  * `dissonanceIndex`
  * `timeSeriesAnalysis`
* 기존 `AnalysisResult` 엔티티 필드 기본값 설정 및 DB 저장 처리
* `AnalysisRequest.analysisResult` 연관관계 연결
* 분석 성공 시 `AnalysisRequest.status`를 `COMPLETED`로 변경
* AI 응답 실패 또는 예외 발생 시 `FAILED` 상태 및 `errorMessage` 저장
* Presigned URL 전체 노출 대신 URL length 및 `X-Amz-Signature` 포함 여부만 로그 출력하도록 수정
* AI 응답 status/message 기반 로그 추가

```
프론트 흐름
1. 업로드 API 호출
2. analysisRequestId, guestResultToken 저장
3. 1~2초마다 결과 조회 API polling
4. status가 PROCESSING이면 로딩 유지
5. status가 COMPLETED이면 결과 화면 표시
6. status가 FAILED이면 실패 메시지 표시
```

## 🔧 변경 사항

<!-- 주요 변경 파일이나 로직을 정리해주세요. -->

* `AiAnalysisResponse.java`

  * AI 서버 응답 DTO 구조 추가

* `AiService.java`

  * AI 응답 DTO 매핑 처리
  * 성공/실패 로직 분기
  * Presigned URL 기반 AI 요청 개선
  * 로그 민감 정보 제거

* `AnalysisService.java`

  * AI 응답 성공 시 분석 결과 저장 흐름 추가
  * `AnalysisRequest` 상태 변경 로직 추가

* `AnalysisResult.java`

  * AI 분석 결과 저장 필드 추가 및 기본값 보완

## ⚠️ 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->

* AI 응답 DTO 구조가 추후 응답 확장(`time_series_analysis`)에 유연하게 대응 가능한지
* `AnalysisRequest` 상태 전이 (`PENDING → PROCESSING → COMPLETED / FAILED`) 흐름이 적절한지
* AI 응답 실패 시 `FAILED` 상태 및 `errorMessage` 저장 방식이 적절한지
* `AnalysisResult` 필드 기본값 처리 방식이 안전한지
* Presigned URL 로그 마스킹 수준이 적절한지
* 트랜잭션 경계에서 분석 결과 저장과 상태 변경이 일관성 있게 처리되는지
