### PR TITLE
feat: 분석 결과 조회 API 구현

### DIFF
--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisService.java
@@ -325,4 +325,52 @@ public class AnalysisService {
             throw new RuntimeException("토큰 해싱 실패", e);
         }
     }
+
+    @Transactional(readOnly = true)
+    public AnalysisRequest getAnalysisRequestForGuest(Long analysisRequestId, String guestResultToken) {
+        AnalysisRequest analysisRequest = getAnalysisRequestById(analysisRequestId);
+
+        if (!Boolean.TRUE.equals(analysisRequest.getIsGuest())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "비회원 결과 조회가 가능한 요청이 아닙니다.");
+        }
+
+        if (guestResultToken == null || guestResultToken.isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "guestResultToken이 필요합니다.");
+        }
+
+        String givenTokenHash = hashToken(guestResultToken);
+        if (!givenTokenHash.equals(analysisRequest.getGuestResultTokenHash())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "토큰이 올바르지 않습니다.");
+        }
+
+        if (analysisRequest.getExpiresAt() != null && LocalDateTime.now().isAfter(analysisRequest.getExpiresAt())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "조회 기간이 만료되었습니다.");
+        }
+
+        return analysisRequest;
+    }
+
+    @Transactional(readOnly = true)
+    public AnalysisRequest getAnalysisRequestForUser(Long analysisRequestId, Long userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+
+        AnalysisRequest analysisRequest = getAnalysisRequestById(analysisRequestId);
+
+        if (Boolean.TRUE.equals(analysisRequest.getIsGuest())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "회원 결과 조회가 가능한 요청이 아닙니다.");
+        }
+
+        if (analysisRequest.getUser() == null || analysisRequest.getUser().getId() == null || !analysisRequest.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 분석 요청만 조회할 수 있습니다.");
+        }
+
+        return analysisRequest;
+    }
+
+    private AnalysisRequest getAnalysisRequestById(Long analysisRequestId) {
+        return analysisRequestRepository.findById(analysisRequestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "분석 요청을 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/com/quadcore/voiceandtext/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/exception/GlobalExceptionHandler.java
@@ -15,7 +15,8 @@ public class GlobalExceptionHandler {
             ex.getMessage(),
             ex.getCause() != null ? ex.getCause().getMessage() : null
         );
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        HttpStatus status = resolveHttpStatus(ex.getErrorCode());
+        return new ResponseEntity<>(errorResponse, status);
     }
 
     @ExceptionHandler(Exception.class)
@@ -26,5 +27,15 @@ public class GlobalExceptionHandler {
             ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private HttpStatus resolveHttpStatus(ErrorCode errorCode) {
+        return switch (errorCode) {
+            case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
+            case FORBIDDEN -> HttpStatus.FORBIDDEN;
+            case RESOURCE_NOT_FOUND, USER_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case INVALID_REQUEST -> HttpStatus.BAD_REQUEST;
+            default -> HttpStatus.BAD_REQUEST;
+        };
     }
 }

--- a/src/main/java/com/quadcore/voiceandtext/presentation/analysis/AnalysisController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/analysis/AnalysisController.java
@@ -1,13 +1,22 @@
 package com.quadcore.voiceandtext.presentation.analysis;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.quadcore.voiceandtext.application.analysis.AnalysisService;
 import com.quadcore.voiceandtext.common.exception.BusinessException;
 import com.quadcore.voiceandtext.common.exception.ErrorCode;
 import com.quadcore.voiceandtext.common.response.ApiResponse;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisResult;
 import com.quadcore.voiceandtext.domain.file.FileSourceType;
+import com.quadcore.voiceandtext.presentation.analysis.dto.AnalysisRequestStatusResponse;
+import com.quadcore.voiceandtext.presentation.analysis.dto.AnalysisResultResponse;
 import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadRequest;
 import com.quadcore.voiceandtext.presentation.analysis.dto.AudioUploadResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +34,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class AnalysisController {
 
     private final AnalysisService analysisService;
+    private final ObjectMapper objectMapper;
+
     private FileSourceType parseSourceType(String sourceType) {
         if (sourceType == null || sourceType.isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_FILE_SOURCE_TYPE);
@@ -56,4 +67,87 @@ public class AnalysisController {
         AudioUploadResponse response = analysisService.uploadAndRequestAnalysis(request, userId);
         return ResponseEntity.ok(ApiResponse.success("음성 분석 요청이 접수되었습니다.", response));
     }
+
+    @GetMapping("/guest/{analysisRequestId}")
+    @Operation(summary = "비회원 분석 결과 조회", description = "guestResultToken을 검증하여 분석 상태와 결과를 조회합니다.")
+    public ResponseEntity<ApiResponse<AnalysisRequestStatusResponse>> getGuestAnalysisResult(
+            @PathVariable Long analysisRequestId,
+            @Parameter(description = "비회원 결과 조회 토큰", required = true)
+            @RequestParam("token") String guestResultToken) {
+
+        AnalysisRequest analysisRequest = analysisService.getAnalysisRequestForGuest(analysisRequestId, guestResultToken);
+        AnalysisRequestStatusResponse response = buildStatusResponse(analysisRequest);
+        return ResponseEntity.ok(ApiResponse.success("분석 결과 조회에 성공했습니다.", response));
+    }
+
+    @GetMapping("/{analysisRequestId}")
+    @Operation(summary = "회원 분석 결과 조회", description = "JWT 인증된 사용자 본인의 분석 요청만 조회할 수 있습니다.")
+    public ResponseEntity<ApiResponse<AnalysisRequestStatusResponse>> getMemberAnalysisResult(
+            @PathVariable Long analysisRequestId,
+            @AuthenticationPrincipal Long userId) {
+
+        AnalysisRequest analysisRequest = analysisService.getAnalysisRequestForUser(analysisRequestId, userId);
+        AnalysisRequestStatusResponse response = buildStatusResponse(analysisRequest);
+        return ResponseEntity.ok(ApiResponse.success("분석 결과 조회에 성공했습니다.", response));
+    }
+
+    private AnalysisRequestStatusResponse buildStatusResponse(AnalysisRequest analysisRequest) {
+        String status = analysisRequest.getStatus().name();
+        String message = buildStatusMessage(analysisRequest.getStatus());
+        String errorMessage = null;
+        if (analysisRequest.getStatus() == com.quadcore.voiceandtext.domain.analysis.AnalysisStatus.FAILED) {
+            errorMessage = analysisRequest.getErrorMessage() != null ? analysisRequest.getErrorMessage() : "분석에 실패했습니다.";
+        }
+
+        AnalysisResultResponse result = null;
+        if (analysisRequest.getStatus() == com.quadcore.voiceandtext.domain.analysis.AnalysisStatus.COMPLETED) {
+            result = buildResultResponse(analysisRequest.getAnalysisResult());
+        }
+
+        return new AnalysisRequestStatusResponse(
+                analysisRequest.getId(),
+                status,
+                message,
+                errorMessage,
+                result
+        );
+    }
+
+    private String buildStatusMessage(com.quadcore.voiceandtext.domain.analysis.AnalysisStatus status) {
+        return switch (status) {
+            case PENDING, PROCESSING -> "분석이 진행 중입니다.";
+            case COMPLETED -> "분석이 완료되었습니다.";
+            case FAILED -> "분석에 실패했습니다.";
+        };
+    }
+
+    private AnalysisResultResponse buildResultResponse(AnalysisResult analysisResult) {
+        if (analysisResult == null) {
+            return null;
+        }
+
+        JsonNode timeSeriesAnalysis = parseTimeSeriesAnalysis(analysisResult.getTimeSeriesAnalysis());
+
+        return new AnalysisResultResponse(
+                analysisResult.getPrimaryEmotion(),
+                analysisResult.getDissonanceIndex(),
+                analysisResult.getSummaryExplanation(),
+                timeSeriesAnalysis
+        );
+    }
+
+    private JsonNode parseTimeSeriesAnalysis(String rawJson) {
+        if (rawJson == null || rawJson.isBlank()) {
+            return objectMapper.createArrayNode();
+        }
+
+        try {
+            JsonNode parsed = objectMapper.readTree(rawJson);
+            return parsed == null || parsed.isNull() ? objectMapper.createArrayNode() : parsed;
+        } catch (Exception e) {
+            log.warn("timeSeriesAnalysis JSON 파싱 실패: {}", e.getMessage());
+            return objectMapper.createArrayNode();
+        }
+    }
 }
+

--- a/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AnalysisRequestStatusResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AnalysisRequestStatusResponse.java
@@ -1,0 +1,10 @@
+package com.quadcore.voiceandtext.presentation.analysis.dto;
+
+public record AnalysisRequestStatusResponse(
+        Long analysisRequestId,
+        String status,
+        String message,
+        String errorMessage,
+        AnalysisResultResponse result
+) {
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AnalysisResultResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/analysis/dto/AnalysisResultResponse.java
@@ -1,0 +1,11 @@
+package com.quadcore.voiceandtext.presentation.analysis.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record AnalysisResultResponse(
+        String primaryEmotion,
+        Double dissonanceIndex,
+        String summaryExplanation,
+        JsonNode timeSeriesAnalysis
+) {
+}


### PR DESCRIPTION
## 🔗 관련 이슈

* close #18

## 📌 개요

<!-- 어떤 작업인지 간단히 설명해주세요. -->

* 회원/비회원 분석 결과 조회 API를 구현하고, 분석 상태에 따른 응답 구조 및 권한 검증 로직을 추가했습니다.

## 🔍 작업 내용

<!-- 어떤 변경을 했는지 구체적으로 작성해주세요. -->

* 회원 분석 결과 조회 API 구현

  * JWT 인증 사용자 기준 본인 요청만 조회 가능하도록 권한 검증 추가
* 비회원 분석 결과 조회 API 구현

  * `guestResultToken` hash 비교 기반 접근 검증 추가
  * 만료 시간(`expiresAt`) 검증 추가
* `AnalysisRequest.status`에 따라 응답 분기 처리

  * `PENDING`, `PROCESSING` → 상태만 반환
  * `COMPLETED` → 분석 결과 반환
  * `FAILED` → `errorMessage` 포함 반환
* `timeSeriesAnalysis` JSON 문자열을 `JsonNode`로 파싱하여 응답하도록 구현

  * null 또는 파싱 실패 시 빈 배열(`[]`) 반환
* Swagger 문서화(`@Operation`) 추가
* `BusinessException`의 `ErrorCode`를 HTTP 상태 코드로 매핑하도록 예외 처리 개선

## 🔧 변경 사항

<!-- 주요 변경 파일이나 로직을 정리해주세요. -->

* `AnalysisController`

  * 회원/비회원 분석 결과 조회 API 추가
  * Swagger 문서화 추가
* `AnalysisService`

  * 분석 결과 조회 로직 구현
  * 회원/비회원 권한 검증 추가
  * 상태별 응답 분기 처리
* `GlobalExceptionHandler`

  * `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `BAD_REQUEST` 상태 매핑 개선
* DTO 추가

  * `AnalysisResultResponse`
  * `AnalysisRequestStatusResponse`

## ⚠️ 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->

* 비회원 결과 조회 시 `guestResultToken` hash 검증 흐름이 적절한지
* 회원 조회 시 본인 요청만 접근 가능하도록 권한 검증이 안전하게 구현되었는지
* `timeSeriesAnalysis` JSON 파싱 및 fallback(`[]`) 처리 방식이 적절한지
* 상태별 응답 구조(`PENDING/PROCESSING/COMPLETED/FAILED`)가 프론트 polling 방식과 맞는지
