### PR TITLE
feat: 관리자 관련 api 구현

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(xargs grep -l \"RestTemplate\")",
-      "Bash(xargs grep -l \"@Async\")"
+      "Bash(xargs grep -l \"@Async\")",
+      "Bash(./gradlew compileJava --quiet)"
     ]
   }
 }

--- a/docs/ADMIN_DB_SQL.md
+++ b/docs/ADMIN_DB_SQL.md
@@ -1,0 +1,6 @@
+-- Add role and status columns to users table
+ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(20) DEFAULT 'USER' NOT NULL;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'ACTIVE' NOT NULL;
+
+-- Assign admin role to an existing user (replace email)
+UPDATE users SET role = 'ADMIN' WHERE email = '관리자이메일@example.com';

--- a/src/main/java/com/quadcore/voiceandtext/application/admin/AdminService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/admin/AdminService.java
@@ -1,0 +1,73 @@
+package com.quadcore.voiceandtext.application.admin;
+
+import com.quadcore.voiceandtext.application.analysis.AnalysisRequestRepository;
+import com.quadcore.voiceandtext.application.auth.UserRepository;
+import com.quadcore.voiceandtext.common.exception.BusinessException;
+import com.quadcore.voiceandtext.common.exception.ErrorCode;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.user.User;
+import com.quadcore.voiceandtext.domain.user.UserRole;
+import com.quadcore.voiceandtext.domain.user.UserStatus;
+import com.quadcore.voiceandtext.presentation.admin.dto.AnalysisLogResponse;
+import com.quadcore.voiceandtext.presentation.admin.dto.UserResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AdminService {
+
+    private final UserRepository userRepository;
+    private final AnalysisRequestRepository analysisRequestRepository;
+
+    public AdminService(UserRepository userRepository, AnalysisRequestRepository analysisRequestRepository) {
+        this.userRepository = userRepository;
+        this.analysisRequestRepository = analysisRequestRepository;
+    }
+
+    private User requireAdmin(Long currentUserId) {
+        if (currentUserId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        }
+        User me = userRepository.findById(currentUserId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (me.getRole() != UserRole.ADMIN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return me;
+    }
+
+    public List<UserResponse> getAllUsers(Long currentUserId) {
+        requireAdmin(currentUserId);
+        return userRepository.findAll().stream().map(UserResponse::from).collect(Collectors.toList());
+    }
+
+    public List<AnalysisLogResponse> getAllLogs(Long currentUserId) {
+        requireAdmin(currentUserId);
+        return analysisRequestRepository.findAll().stream().map(AnalysisLogResponse::from).collect(Collectors.toList());
+    }
+
+    public List<AnalysisLogResponse> getUserLogs(Long currentUserId, Long userId) {
+        requireAdmin(currentUserId);
+        userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return analysisRequestRepository.findByUserId(userId).stream().map(AnalysisLogResponse::from).collect(Collectors.toList());
+    }
+
+    public void updateUserStatus(Long currentUserId, Long userId, String statusStr) {
+        User me = requireAdmin(currentUserId);
+        User target = userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        UserStatus newStatus;
+        try {
+            newStatus = UserStatus.valueOf(statusStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_USER_STATUS);
+        }
+
+        if (me.getId().equals(target.getId()) && newStatus != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.CANNOT_CHANGE_OWN_STATUS);
+        }
+
+        target.setStatus(newStatus);
+        userRepository.save(target);
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/application/admin/AdminService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/admin/AdminService.java
@@ -57,6 +57,9 @@ public class AdminService {
         User me = requireAdmin(currentUserId);
         User target = userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         UserStatus newStatus;
+        if (statusStr == null || statusStr.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_USER_STATUS);
+        }
         try {
             newStatus = UserStatus.valueOf(statusStr.toUpperCase());
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/quadcore/voiceandtext/application/admin/AdminService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/admin/AdminService.java
@@ -10,10 +10,10 @@ import com.quadcore.voiceandtext.domain.user.UserRole;
 import com.quadcore.voiceandtext.domain.user.UserStatus;
 import com.quadcore.voiceandtext.presentation.admin.dto.AnalysisLogResponse;
 import com.quadcore.voiceandtext.presentation.admin.dto.UserResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class AdminService {
@@ -37,20 +37,20 @@ public class AdminService {
         return me;
     }
 
-    public List<UserResponse> getAllUsers(Long currentUserId) {
+    public Page<UserResponse> getAllUsers(Long currentUserId, Pageable pageable) {
         requireAdmin(currentUserId);
-        return userRepository.findAll().stream().map(UserResponse::from).collect(Collectors.toList());
+        return userRepository.findAll(pageable).map(UserResponse::from);
     }
 
-    public List<AnalysisLogResponse> getAllLogs(Long currentUserId) {
+    public Page<AnalysisLogResponse> getAllLogs(Long currentUserId, Pageable pageable) {
         requireAdmin(currentUserId);
-        return analysisRequestRepository.findAll().stream().map(AnalysisLogResponse::from).collect(Collectors.toList());
+        return analysisRequestRepository.findAll(pageable).map(AnalysisLogResponse::from);
     }
 
-    public List<AnalysisLogResponse> getUserLogs(Long currentUserId, Long userId) {
+    public Page<AnalysisLogResponse> getUserLogs(Long currentUserId, Long userId, Pageable pageable) {
         requireAdmin(currentUserId);
         userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        return analysisRequestRepository.findByUserId(userId).stream().map(AnalysisLogResponse::from).collect(Collectors.toList());
+        return analysisRequestRepository.findByUserId(userId, pageable).map(AnalysisLogResponse::from);
     }
 
     public void updateUserStatus(Long currentUserId, Long userId, String statusStr) {

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
@@ -1,6 +1,8 @@
 package com.quadcore.voiceandtext.application.analysis;
 
 import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,7 +14,7 @@ public interface AnalysisRequestRepository {
     List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(LocalDateTime expiresAt);
     void delete(AnalysisRequest analysisRequest);
 
-    List<AnalysisRequest> findAll();
+    Page<AnalysisRequest> findAll(Pageable pageable);
 
-    List<AnalysisRequest> findByUserId(Long userId);
+    Page<AnalysisRequest> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
@@ -11,4 +11,8 @@ public interface AnalysisRequestRepository {
     Optional<AnalysisRequest> findById(Long id);
     List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(LocalDateTime expiresAt);
     void delete(AnalysisRequest analysisRequest);
+
+    List<AnalysisRequest> findAll();
+
+    List<AnalysisRequest> findByUserId(Long userId);
 }

--- a/src/main/java/com/quadcore/voiceandtext/application/auth/UserRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/auth/UserRepository.java
@@ -3,6 +3,7 @@ package com.quadcore.voiceandtext.application.auth;
 import com.quadcore.voiceandtext.domain.user.User;
 
 import java.util.Optional;
+import java.util.List;
 
 /**
  * User 저장소 포트
@@ -35,6 +36,8 @@ public interface UserRepository {
      * @return 찾은 사용자, 없으면 빈 Optional
      */
     Optional<User> findById(Long id);
+
+    List<User> findAll();
 
     /**
      * 사용자를 저장합니다.

--- a/src/main/java/com/quadcore/voiceandtext/application/auth/UserRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/auth/UserRepository.java
@@ -2,8 +2,10 @@ package com.quadcore.voiceandtext.application.auth;
 
 import com.quadcore.voiceandtext.domain.user.User;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
-import java.util.List;
 
 /**
  * User 저장소 포트
@@ -37,7 +39,7 @@ public interface UserRepository {
      */
     Optional<User> findById(Long id);
 
-    List<User> findAll();
+    Page<User> findAll(Pageable pageable);
 
     /**
      * 사용자를 저장합니다.

--- a/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
@@ -8,6 +8,8 @@ public enum ErrorCode {
     FORBIDDEN("FORBIDDEN", "접근이 거부되었습니다."),
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
     USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    INVALID_USER_STATUS("INVALID_USER_STATUS", "유효하지 않은 사용자 상태입니다."),
+    CANNOT_CHANGE_OWN_STATUS("CANNOT_CHANGE_OWN_STATUS", "관리자는 자신의 상태를 비활성 또는 정지로 변경할 수 없습니다."),
     INVALID_FILE_SOURCE_TYPE("INVALID_FILE_SOURCE_TYPE", "sourceType은 UPLOAD 또는 RECORD만 가능합니다.");
 
     private final String code;

--- a/src/main/java/com/quadcore/voiceandtext/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/exception/GlobalExceptionHandler.java
@@ -34,6 +34,8 @@ public class GlobalExceptionHandler {
             case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
             case FORBIDDEN -> HttpStatus.FORBIDDEN;
             case RESOURCE_NOT_FOUND, USER_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case CANNOT_CHANGE_OWN_STATUS -> HttpStatus.FORBIDDEN;
+            case INVALID_USER_STATUS -> HttpStatus.BAD_REQUEST;
             case INVALID_REQUEST -> HttpStatus.BAD_REQUEST;
             default -> HttpStatus.BAD_REQUEST;
         };

--- a/src/main/java/com/quadcore/voiceandtext/domain/user/User.java
+++ b/src/main/java/com/quadcore/voiceandtext/domain/user/User.java
@@ -29,11 +29,11 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private UserRole role;
+    private UserRole role = UserRole.USER;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private UserStatus status;
+    private UserStatus status = UserStatus.ACTIVE;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
@@ -14,6 +14,10 @@ import java.util.Optional;
 interface SpringDataAnalysisRequestJpaRepository extends JpaRepository<AnalysisRequest, Long> {
     @Query("SELECT ar FROM AnalysisRequest ar WHERE ar.isGuest = true AND ar.expiresAt < :expiresAt")
     List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(@Param("expiresAt") LocalDateTime expiresAt);
+
+    List<AnalysisRequest> findAll();
+
+    List<AnalysisRequest> findByUser_Id(Long userId);
 }
 
 @Component
@@ -43,5 +47,15 @@ public class JpaAnalysisRequestRepository implements AnalysisRequestRepository {
     @Override
     public void delete(AnalysisRequest analysisRequest) {
         springDataRepository.delete(analysisRequest);
+    }
+
+    @Override
+    public List<AnalysisRequest> findAll() {
+        return springDataRepository.findAll();
+    }
+
+    @Override
+    public List<AnalysisRequest> findByUserId(Long userId) {
+        return springDataRepository.findByUser_Id(userId);
     }
 }

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
@@ -2,6 +2,8 @@ package com.quadcore.voiceandtext.infrastructure.persistence;
 
 import com.quadcore.voiceandtext.application.analysis.AnalysisRequestRepository;
 import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,9 +17,7 @@ interface SpringDataAnalysisRequestJpaRepository extends JpaRepository<AnalysisR
     @Query("SELECT ar FROM AnalysisRequest ar WHERE ar.isGuest = true AND ar.expiresAt < :expiresAt")
     List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(@Param("expiresAt") LocalDateTime expiresAt);
 
-    List<AnalysisRequest> findAll();
-
-    List<AnalysisRequest> findByUser_Id(Long userId);
+    Page<AnalysisRequest> findByUser_Id(Long userId, Pageable pageable);
 }
 
 @Component
@@ -50,12 +50,12 @@ public class JpaAnalysisRequestRepository implements AnalysisRequestRepository {
     }
 
     @Override
-    public List<AnalysisRequest> findAll() {
-        return springDataRepository.findAll();
+    public Page<AnalysisRequest> findAll(Pageable pageable) {
+        return springDataRepository.findAll(pageable);
     }
 
     @Override
-    public List<AnalysisRequest> findByUserId(Long userId) {
-        return springDataRepository.findByUser_Id(userId);
+    public Page<AnalysisRequest> findByUserId(Long userId, Pageable pageable) {
+        return springDataRepository.findByUser_Id(userId, pageable);
     }
 }

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaUserRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaUserRepository.java
@@ -40,4 +40,9 @@ public class JpaUserRepository implements UserRepository {
     public User save(User user) {
         return springDataUserJpaRepository.save(user);
     }
+
+    @Override
+    public java.util.List<User> findAll() {
+        return springDataUserJpaRepository.findAll();
+    }
 }

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaUserRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaUserRepository.java
@@ -2,6 +2,8 @@ package com.quadcore.voiceandtext.infrastructure.persistence;
 
 import com.quadcore.voiceandtext.application.auth.UserRepository;
 import com.quadcore.voiceandtext.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -42,7 +44,7 @@ public class JpaUserRepository implements UserRepository {
     }
 
     @Override
-    public java.util.List<User> findAll() {
-        return springDataUserJpaRepository.findAll();
+    public Page<User> findAll(Pageable pageable) {
+        return springDataUserJpaRepository.findAll(pageable);
     }
 }

--- a/src/main/java/com/quadcore/voiceandtext/presentation/admin/AdminController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/admin/AdminController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
@@ -57,7 +58,7 @@ public class AdminController {
     @PatchMapping("/users/{userId}/status")
     @Operation(summary = "사용자 상태 변경", description = "관리자만 접근 가능")
     @SecurityRequirement(name = "bearer-jwt")
-    public ResponseEntity<ApiResponse<Void>> updateUserStatus(@AuthenticationPrincipal Long userId, @PathVariable("userId") Long userIdPath, @RequestBody UpdateUserStatusRequest request) {
+    public ResponseEntity<ApiResponse<Void>> updateUserStatus(@AuthenticationPrincipal Long userId, @PathVariable("userId") Long userIdPath, @Valid @RequestBody UpdateUserStatusRequest request) {
         if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
         adminService.updateUserStatus(userId, userIdPath, request.getStatus());
         return ResponseEntity.ok(ApiResponse.success("사용자 상태가 변경되었습니다."));

--- a/src/main/java/com/quadcore/voiceandtext/presentation/admin/AdminController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/admin/AdminController.java
@@ -1,0 +1,65 @@
+package com.quadcore.voiceandtext.presentation.admin;
+
+import com.quadcore.voiceandtext.application.admin.AdminService;
+import com.quadcore.voiceandtext.common.exception.BusinessException;
+import com.quadcore.voiceandtext.common.exception.ErrorCode;
+import com.quadcore.voiceandtext.common.response.ApiResponse;
+import com.quadcore.voiceandtext.presentation.admin.dto.AnalysisLogResponse;
+import com.quadcore.voiceandtext.presentation.admin.dto.UpdateUserStatusRequest;
+import com.quadcore.voiceandtext.presentation.admin.dto.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@Tag(name = "Admin", description = "관리자 전용 API")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    @GetMapping("/users")
+    @Operation(summary = "전체 사용자 조회", description = "관리자만 접근 가능")
+    @SecurityRequirement(name = "bearer-jwt")
+    public ResponseEntity<ApiResponse<List<UserResponse>>> getAllUsers(@AuthenticationPrincipal Long userId) {
+        if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        List<UserResponse> users = adminService.getAllUsers(userId);
+        return ResponseEntity.ok(ApiResponse.success(users));
+    }
+
+    @GetMapping("/logs")
+    @Operation(summary = "전체 로그 조회", description = "관리자만 접근 가능")
+    @SecurityRequirement(name = "bearer-jwt")
+    public ResponseEntity<ApiResponse<List<AnalysisLogResponse>>> getAllLogs(@AuthenticationPrincipal Long userId) {
+        if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        List<AnalysisLogResponse> logs = adminService.getAllLogs(userId);
+        return ResponseEntity.ok(ApiResponse.success(logs));
+    }
+
+    @GetMapping("/users/{userId}/logs")
+    @Operation(summary = "사용자별 로그 조회", description = "관리자만 접근 가능")
+    @SecurityRequirement(name = "bearer-jwt")
+    public ResponseEntity<ApiResponse<List<AnalysisLogResponse>>> getUserLogs(@AuthenticationPrincipal Long userId, @PathVariable("userId") Long userIdPath) {
+        if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        List<AnalysisLogResponse> logs = adminService.getUserLogs(userId, userIdPath);
+        return ResponseEntity.ok(ApiResponse.success(logs));
+    }
+
+    @PatchMapping("/users/{userId}/status")
+    @Operation(summary = "사용자 상태 변경", description = "관리자만 접근 가능")
+    @SecurityRequirement(name = "bearer-jwt")
+    public ResponseEntity<ApiResponse<Void>> updateUserStatus(@AuthenticationPrincipal Long userId, @PathVariable("userId") Long userIdPath, @RequestBody UpdateUserStatusRequest request) {
+        if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        adminService.updateUserStatus(userId, userIdPath, request.getStatus());
+        return ResponseEntity.ok(ApiResponse.success("사용자 상태가 변경되었습니다."));
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/admin/AdminController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/admin/AdminController.java
@@ -10,6 +10,9 @@ import com.quadcore.voiceandtext.presentation.admin.dto.UserResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -31,27 +34,34 @@ public class AdminController {
     @GetMapping("/users")
     @Operation(summary = "전체 사용자 조회", description = "관리자만 접근 가능")
     @SecurityRequirement(name = "bearer-jwt")
-    public ResponseEntity<ApiResponse<List<UserResponse>>> getAllUsers(@AuthenticationPrincipal Long userId) {
+    public ResponseEntity<ApiResponse<Page<UserResponse>>> getAllUsers(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 20) Pageable pageable) {
         if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
-        List<UserResponse> users = adminService.getAllUsers(userId);
+        Page<UserResponse> users = adminService.getAllUsers(userId, pageable);
         return ResponseEntity.ok(ApiResponse.success(users));
     }
 
     @GetMapping("/logs")
     @Operation(summary = "전체 로그 조회", description = "관리자만 접근 가능")
     @SecurityRequirement(name = "bearer-jwt")
-    public ResponseEntity<ApiResponse<List<AnalysisLogResponse>>> getAllLogs(@AuthenticationPrincipal Long userId) {
+    public ResponseEntity<ApiResponse<Page<AnalysisLogResponse>>> getAllLogs(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 20) Pageable pageable) {
         if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
-        List<AnalysisLogResponse> logs = adminService.getAllLogs(userId);
+        Page<AnalysisLogResponse> logs = adminService.getAllLogs(userId, pageable);
         return ResponseEntity.ok(ApiResponse.success(logs));
     }
 
     @GetMapping("/users/{userId}/logs")
     @Operation(summary = "사용자별 로그 조회", description = "관리자만 접근 가능")
     @SecurityRequirement(name = "bearer-jwt")
-    public ResponseEntity<ApiResponse<List<AnalysisLogResponse>>> getUserLogs(@AuthenticationPrincipal Long userId, @PathVariable("userId") Long userIdPath) {
+    public ResponseEntity<ApiResponse<Page<AnalysisLogResponse>>> getUserLogs(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("userId") Long userIdPath,
+            @PageableDefault(size = 20) Pageable pageable) {
         if (userId == null) throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
-        List<AnalysisLogResponse> logs = adminService.getUserLogs(userId, userIdPath);
+        Page<AnalysisLogResponse> logs = adminService.getUserLogs(userId, userIdPath, pageable);
         return ResponseEntity.ok(ApiResponse.success(logs));
     }
 

--- a/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/AnalysisLogResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/AnalysisLogResponse.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 public class AnalysisLogResponse {
     private Long analysisRequestId;
     private Long userId;
+    private boolean isGuest;
     private AnalysisStatus status;
     private FileSourceType sourceType;
     private String errorMessage;
@@ -29,6 +30,7 @@ public class AnalysisLogResponse {
         return AnalysisLogResponse.builder()
                 .analysisRequestId(ar.getId())
                 .userId(ar.getUser() != null ? ar.getUser().getId() : null)
+                .isGuest(ar.getIsGuest())
                 .status(ar.getStatus())
                 .sourceType(sourceType)
                 .errorMessage(ar.getErrorMessage())

--- a/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/AnalysisLogResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/AnalysisLogResponse.java
@@ -1,0 +1,39 @@
+package com.quadcore.voiceandtext.presentation.admin.dto;
+
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisStatus;
+import com.quadcore.voiceandtext.domain.file.FileSourceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AnalysisLogResponse {
+    private Long analysisRequestId;
+    private Long userId;
+    private AnalysisStatus status;
+    private FileSourceType sourceType;
+    private String errorMessage;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static AnalysisLogResponse from(AnalysisRequest ar) {
+        FileSourceType sourceType = null;
+        if (ar.getAudioFile() != null) {
+            sourceType = ar.getAudioFile().getSourceType();
+        }
+        return AnalysisLogResponse.builder()
+                .analysisRequestId(ar.getId())
+                .userId(ar.getUser() != null ? ar.getUser().getId() : null)
+                .status(ar.getStatus())
+                .sourceType(sourceType)
+                .errorMessage(ar.getErrorMessage())
+                .createdAt(ar.getCreatedAt())
+                .updatedAt(ar.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/UpdateUserStatusRequest.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/UpdateUserStatusRequest.java
@@ -1,0 +1,8 @@
+package com.quadcore.voiceandtext.presentation.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserStatusRequest {
+    private String status;
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/UserResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/admin/dto/UserResponse.java
@@ -1,0 +1,33 @@
+package com.quadcore.voiceandtext.presentation.admin.dto;
+
+import com.quadcore.voiceandtext.domain.user.User;
+import com.quadcore.voiceandtext.domain.user.UserRole;
+import com.quadcore.voiceandtext.domain.user.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserResponse {
+    private Long userId;
+    private String email;
+    private String name;
+    private UserRole role;
+    private UserStatus status;
+    private LocalDateTime createdAt;
+
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .role(user.getRole())
+                .status(user.getStatus())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

* close #21 

## 📌 개요

<!-- 어떤 작업인지 간단히 설명해주세요. -->

* 관리자 페이지 기능 지원을 위한 관리자 API를 구현했습니다.
* 사용자 관리 및 분석 로그 조회 기능을 추가했습니다.

## 🔍 작업 내용

<!-- 어떤 변경을 했는지 구체적으로 작성해주세요. -->

* 관리자 권한(Role) 기반 접근 제어 추가
* 사용자 상태(UserStatus) 관리 기능 추가
* 전체 사용자 조회 API 구현
* 전체 분석 로그 조회 API 구현
* 사용자별 분석 로그 조회 API 구현
* 사용자 상태 변경 API 구현
* 관리자 API Swagger 문서화 추가
* 관리자 권한 및 예외 처리 로직 추가

## 🔧 변경 사항

<!-- 주요 변경 파일이나 로직을 정리해주세요. -->

* `User`

  * `role`, `status` 필드 추가
* `UserRole`, `UserStatus`

  * enum 추가
* `AdminController`

  * 관리자 API 엔드포인트 추가
* `AdminService`

  * 관리자 권한 검증 및 사용자/로그 관리 로직 구현
* `UserRepository`, `AnalysisRequestRepository`

  * 관리자 조회용 메서드 추가
* DTO 추가

  * 사용자 조회 응답 DTO
  * 로그 조회 응답 DTO
  * 상태 변경 요청/응답 DTO
* `GlobalExceptionHandler`, `ErrorCode`

  * 관리자 관련 예외 처리 추가

## ⚠️ 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->

* 관리자 권한 검증(role == ADMIN) 로직이 안전하게 적용되었는지
* 사용자 상태 변경 시 자기 자신의 계정을 비활성화/정지하지 못하도록 처리한 로직이 적절한지
* 로그 조회 범위를 `AnalysisRequest` 기반으로 구현한 방향이 적절한지
* role/status 컬럼 추가에 따른 기존 사용자 기본값 처리 방식이 적절한지
