### PR TITLE
feat: 회원 음성 파일 조회 및 관리 API 구현

### DIFF
--- a/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/analysis/AnalysisRequestRepository.java
@@ -17,4 +17,6 @@ public interface AnalysisRequestRepository {
     Page<AnalysisRequest> findAll(Pageable pageable);
 
     Page<AnalysisRequest> findByUserId(Long userId, Pageable pageable);
+
+    Page<AnalysisRequest> findByUserIdWithAudioFile(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/quadcore/voiceandtext/application/file/AudioFileService.java
+++ b/src/main/java/com/quadcore/voiceandtext/application/file/AudioFileService.java
@@ -1,0 +1,82 @@
+package com.quadcore.voiceandtext.application.file;
+
+import com.quadcore.voiceandtext.application.analysis.AnalysisRequestRepository;
+import com.quadcore.voiceandtext.application.analysis.FileStoragePort;
+import com.quadcore.voiceandtext.common.exception.BusinessException;
+import com.quadcore.voiceandtext.common.exception.ErrorCode;
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.file.AudioFile;
+import com.quadcore.voiceandtext.presentation.file.dto.AudioFileResponse;
+import com.quadcore.voiceandtext.presentation.file.dto.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class AudioFileService {
+
+    private static final int PRESIGNED_URL_EXPIRY_SECONDS = 900; // 15분
+
+    private final AnalysisRequestRepository analysisRequestRepository;
+    private final FileStoragePort fileStoragePort;
+
+    @Transactional(readOnly = true)
+    public Page<AudioFileResponse> getMyAudioFiles(Long userId, Pageable pageable) {
+        requireAuth(userId);
+        return analysisRequestRepository.findByUserIdWithAudioFile(userId, pageable)
+                .map(req -> AudioFileResponse.from(req, req.getAudioFile()));
+    }
+
+    @Transactional(readOnly = true)
+    public PresignedUrlResponse getPresignedUrl(Long userId, Long analysisRequestId) {
+        requireAuth(userId);
+        AudioFile audioFile = getOwnedAudioFile(userId, analysisRequestId);
+        String url = fileStoragePort.generatePresignedUrl(
+                audioFile.getStorageLocation(), Duration.ofSeconds(PRESIGNED_URL_EXPIRY_SECONDS));
+        return new PresignedUrlResponse(url, PRESIGNED_URL_EXPIRY_SECONDS);
+    }
+
+    @Transactional
+    public void deleteAudioFile(Long userId, Long analysisRequestId) {
+        requireAuth(userId);
+        AnalysisRequest req = getOwnedAnalysisRequest(userId, analysisRequestId);
+        AudioFile audioFile = req.getAudioFile();
+        if (audioFile == null) {
+            throw new BusinessException(ErrorCode.AUDIO_FILE_NOT_FOUND);
+        }
+        fileStoragePort.deleteFile(audioFile.getStorageLocation());
+        req.setAudioFile(null);
+        analysisRequestRepository.save(req);
+    }
+
+    private AudioFile getOwnedAudioFile(Long userId, Long analysisRequestId) {
+        AnalysisRequest req = getOwnedAnalysisRequest(userId, analysisRequestId);
+        AudioFile audioFile = req.getAudioFile();
+        if (audioFile == null) {
+            throw new BusinessException(ErrorCode.AUDIO_FILE_NOT_FOUND);
+        }
+        return audioFile;
+    }
+
+    private AnalysisRequest getOwnedAnalysisRequest(Long userId, Long analysisRequestId) {
+        AnalysisRequest req = analysisRequestRepository.findById(analysisRequestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "분석 요청을 찾을 수 없습니다."));
+        if (Boolean.TRUE.equals(req.getIsGuest())
+                || req.getUser() == null
+                || !req.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 파일만 접근할 수 있습니다.");
+        }
+        return req;
+    }
+
+    private void requireAuth(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
+++ b/src/main/java/com/quadcore/voiceandtext/common/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     INVALID_USER_STATUS("INVALID_USER_STATUS", "유효하지 않은 사용자 상태입니다."),
     CANNOT_CHANGE_OWN_STATUS("CANNOT_CHANGE_OWN_STATUS", "관리자는 자신의 상태를 비활성 또는 정지로 변경할 수 없습니다."),
-    INVALID_FILE_SOURCE_TYPE("INVALID_FILE_SOURCE_TYPE", "sourceType은 UPLOAD 또는 RECORD만 가능합니다.");
+    INVALID_FILE_SOURCE_TYPE("INVALID_FILE_SOURCE_TYPE", "sourceType은 UPLOAD 또는 RECORD만 가능합니다."),
+    AUDIO_FILE_NOT_FOUND("AUDIO_FILE_NOT_FOUND", "음성 파일을 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
+++ b/src/main/java/com/quadcore/voiceandtext/infrastructure/persistence/JpaAnalysisRequestRepository.java
@@ -18,6 +18,10 @@ interface SpringDataAnalysisRequestJpaRepository extends JpaRepository<AnalysisR
     List<AnalysisRequest> findByIsGuestTrueAndExpiresAtBefore(@Param("expiresAt") LocalDateTime expiresAt);
 
     Page<AnalysisRequest> findByUser_Id(Long userId, Pageable pageable);
+
+    @Query(value = "SELECT ar FROM AnalysisRequest ar JOIN FETCH ar.audioFile WHERE ar.user.id = :userId",
+           countQuery = "SELECT COUNT(ar) FROM AnalysisRequest ar WHERE ar.user.id = :userId AND ar.audioFile IS NOT NULL")
+    Page<AnalysisRequest> findByUser_IdWithAudioFile(@Param("userId") Long userId, Pageable pageable);
 }
 
 @Component
@@ -57,5 +61,10 @@ public class JpaAnalysisRequestRepository implements AnalysisRequestRepository {
     @Override
     public Page<AnalysisRequest> findByUserId(Long userId, Pageable pageable) {
         return springDataRepository.findByUser_Id(userId, pageable);
+    }
+
+    @Override
+    public Page<AnalysisRequest> findByUserIdWithAudioFile(Long userId, Pageable pageable) {
+        return springDataRepository.findByUser_IdWithAudioFile(userId, pageable);
     }
 }

--- a/src/main/java/com/quadcore/voiceandtext/presentation/file/AudioFileController.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/file/AudioFileController.java
@@ -1,0 +1,53 @@
+package com.quadcore.voiceandtext.presentation.file;
+
+import com.quadcore.voiceandtext.application.file.AudioFileService;
+import com.quadcore.voiceandtext.common.response.ApiResponse;
+import com.quadcore.voiceandtext.presentation.file.dto.AudioFileResponse;
+import com.quadcore.voiceandtext.presentation.file.dto.PresignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@Tag(name = "AudioFile", description = "음성 파일 관리 API (회원 전용)")
+@SecurityRequirement(name = "bearer-jwt")
+@RequiredArgsConstructor
+public class AudioFileController {
+
+    private final AudioFileService audioFileService;
+
+    @GetMapping
+    @Operation(summary = "내 음성 파일 목록 조회", description = "본인이 업로드한 음성 파일 목록을 페이지네이션으로 조회합니다.")
+    public ResponseEntity<ApiResponse<Page<AudioFileResponse>>> getMyAudioFiles(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<AudioFileResponse> files = audioFileService.getMyAudioFiles(userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(files));
+    }
+
+    @GetMapping("/{analysisRequestId}/presigned-url")
+    @Operation(summary = "음성 파일 재생 링크 발급", description = "S3 Presigned URL(15분 유효)을 발급합니다. 본인 파일만 접근 가능합니다.")
+    public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long analysisRequestId) {
+        PresignedUrlResponse response = audioFileService.getPresignedUrl(userId, analysisRequestId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{analysisRequestId}")
+    @Operation(summary = "음성 파일 삭제", description = "S3에서 파일을 삭제하고 연결을 해제합니다. 본인 파일만 삭제 가능하며, 분석 결과는 유지됩니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteAudioFile(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long analysisRequestId) {
+        audioFileService.deleteAudioFile(userId, analysisRequestId);
+        return ResponseEntity.ok(ApiResponse.success("음성 파일이 삭제되었습니다."));
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/file/dto/AudioFileResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/file/dto/AudioFileResponse.java
@@ -1,0 +1,33 @@
+package com.quadcore.voiceandtext.presentation.file.dto;
+
+import com.quadcore.voiceandtext.domain.analysis.AnalysisRequest;
+import com.quadcore.voiceandtext.domain.file.AudioFile;
+import com.quadcore.voiceandtext.domain.file.FileSourceType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AudioFileResponse {
+    private Long analysisRequestId;
+    private String originalFileName;
+    private Long fileSizeBytes;
+    private Integer durationSeconds;
+    private String mimeType;
+    private FileSourceType sourceType;
+    private LocalDateTime uploadedAt;
+
+    public static AudioFileResponse from(AnalysisRequest analysisRequest, AudioFile audioFile) {
+        return AudioFileResponse.builder()
+                .analysisRequestId(analysisRequest.getId())
+                .originalFileName(audioFile.getOriginalFileName())
+                .fileSizeBytes(audioFile.getFileSizeBytes())
+                .durationSeconds(audioFile.getDurationSeconds())
+                .mimeType(audioFile.getMimeType())
+                .sourceType(audioFile.getSourceType())
+                .uploadedAt(audioFile.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/quadcore/voiceandtext/presentation/file/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/quadcore/voiceandtext/presentation/file/dto/PresignedUrlResponse.java
@@ -1,0 +1,11 @@
+package com.quadcore.voiceandtext.presentation.file.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PresignedUrlResponse {
+    private String presignedUrl;
+    private int expiresInSeconds;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

* close #22

## 📌 개요

<!-- 어떤 작업인지 간단히 설명해주세요. -->

* 회원이 업로드한 음성 파일 목록 조회, 음성 재생 링크 조회, 파일 삭제 기능을 위한 API를 구현했습니다.
* 분석 기록은 유지하면서 음성 파일만 관리할 수 있도록 파일 관리 기능을 추가했습니다.

## 🔍 작업 내용

<!-- 어떤 변경을 했는지 구체적으로 작성해주세요. -->

* 회원 전용 음성 파일 목록 조회 API 구현

  * 로그인한 사용자가 업로드한 음성 파일만 조회
  * 최신순 정렬 및 Pageable 기반 페이지네이션 적용
* 음성 파일 재생용 Presigned URL 조회 API 구현

  * S3 Presigned URL 기반 재생 링크 발급
  * 본인 파일만 접근 가능하도록 권한 검증 추가
* 음성 파일 삭제 API 구현

  * 본인 파일만 삭제 가능
  * S3 객체 삭제 처리 포함
  * 분석 결과(`AnalysisRequest`, `AnalysisResult`)는 유지하고 `AudioFile`만 삭제
* JWT 인증 기반 회원 접근 제한 적용
* Swagger 문서화 추가
* 파일 조회 시 N+1 방지를 위해 `JOIN FETCH + countQuery` 적용

## 🔧 변경 사항

<!-- 주요 변경 파일이나 로직을 정리해주세요. -->

* `AudioFileController`

  * 파일 목록 조회 API 추가
  * Presigned URL 조회 API 추가
  * 파일 삭제 API 추가
* `AudioFileService`

  * 목록 조회 / 재생 링크 발급 / 삭제 로직 구현
  * 본인 파일 검증 로직 추가
* `AudioFileResponse`

  * 파일 목록 응답 DTO 추가
* `PresignedUrlResponse`

  * 재생 링크 응답 DTO 추가
* `AnalysisRequestRepository`

  * 회원 파일 조회용 메서드 추가
* `JpaAnalysisRequestRepository`

  * `JOIN FETCH` 기반 조회 및 countQuery 추가
* `ErrorCode`

  * `AUDIO_FILE_NOT_FOUND` 추가

## ⚠️ 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->

* 파일 접근 권한 검증(user.id == 로그인 사용자)이 안전하게 구현되었는지
* 파일 삭제 시 `AudioFile`만 제거되고 분석 기록(`AnalysisRequest`, `AnalysisResult`)은 정상 유지되는지
* Presigned URL 발급 및 만료 시간 설정이 적절한지
* 페이지네이션 및 `JOIN FETCH + countQuery` 적용 방식이 적절한지
